### PR TITLE
Update to work with JuMP 0.13.0

### DIFF
--- a/examples/jump_minlp.jl
+++ b/examples/jump_minlp.jl
@@ -32,14 +32,14 @@ m = Model(solver=KnitroSolver(mip_method = KTR_MIP_METHOD_BB,
                               KTR_PARAM_MIP_MAXNODES = 10000,
                               KTR_PARAM_HESSIAN_NO_F = KTR_HESSIAN_NO_F_ALLOW))
 x_U = [2,2,1]
-@defVar(m, x_U[i] >= x[i=1:3] >= 0)
-@defVar(m, y[4:6], Bin)
+@variable(m, x_U[i] >= x[i=1:3] >= 0)
+@variable(m, y[4:6], Bin)
 
-@setNLObjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(x[1]-x[2]+1))
-@addNLConstraint(m, 0.8*log(x[2] + 1) + 0.96*log(x[1] - x[2] + 1) - 0.8*x[3] >= 0)
-@addNLConstraint(m, log(x[2] + 1) + 1.2*log(x[1] - x[2] + 1) - x[3] - 2*y[6] >= -2)
-@addNLConstraint(m, x[2] - x[1] <= 0)
-@addNLConstraint(m, x[2] - 2*y[4] <= 0)
-@addNLConstraint(m, x[1] - x[2] - 2*y[5] <= 0)
-@addNLConstraint(m, y[4] + y[5] <= 1)
+@NLobjective(m, Min, 10 + 10*x[1] - 7*x[3] + 5*y[4] + 6*y[5] + 8*y[6] - 18*log(x[2]+1) - 19.2*log(x[1]-x[2]+1))
+@NLobjective(m, 0.8*log(x[2] + 1) + 0.96*log(x[1] - x[2] + 1) - 0.8*x[3] >= 0)
+@NLobjective(m, log(x[2] + 1) + 1.2*log(x[1] - x[2] + 1) - x[3] - 2*y[6] >= -2)
+@NLobjective(m, x[2] - x[1] <= 0)
+@NLobjective(m, x[2] - 2*y[4] <= 0)
+@NLobjective(m, x[1] - x[2] - 2*y[5] <= 0)
+@NLobjective(m, y[4] + y[5] <= 1)
 solve(m)


### PR DESCRIPTION
I made this changes:

@addVar -> @variable
@addConstraint -> @constraint
@setNLObjective -> NLobjective


Now this example should pass the JuMP test without deprecated warnings.