### PR TITLE
Update work with JuMP 0.13.0 please!

### DIFF
--- a/examples/jump_hs035_options.jl
+++ b/examples/jump_hs035_options.jl
@@ -7,14 +7,14 @@ for m in [Model(solver=KnitroSolver()),
                                                           "tuner-fixed.opt"))),
           Model(solver=KnitroSolver(tuner_file=joinpath(dirname(@__FILE__),
                                                         "tuner-explore.opt")))]
-    @defVar(m, x[1:3]>=0)
-    @setNLObjective(m, Min, 9.0 - 8.0*x[1] - 6.0*x[2] - 4.0*x[3]
+    @variable(m, x[1:3]>=0)
+    @NLobjective(m, Min, 9.0 - 8.0*x[1] - 6.0*x[2] - 4.0*x[3]
                             + 2.0*x[1]^2 + 2.0*x[2]^2 + x[3]^2
                             + 2.0*x[1]*x[2] + 2.0*x[1]*x[3])
-    @addConstraint(m, x[1] + x[2] + 2.0*x[3] <= 3)
+    @constraint(m, x[1] + x[2] + 2.0*x[3] <= 3)
     solve(m)
-    @test_approx_eq_eps getValue(x[1]) 1.3333333 1e-5
-    @test_approx_eq_eps getValue(x[2]) 0.7777777 1e-5
-    @test_approx_eq_eps getValue(x[3]) 0.4444444 1e-5
+    @test_approx_eq_eps getvalue(x[1]) 1.3333333 1e-5
+    @test_approx_eq_eps getvalue(x[2]) 0.7777777 1e-5
+    @test_approx_eq_eps getvalue(x[3]) 0.4444444 1e-5
     @test_approx_eq_eps getObjectiveValue(m) 0.1111111 1e-5
 end


### PR DESCRIPTION
I made these changes:

@addVar -> @variable
@addConstraint -> @constraint
@setNLObjective -> NLobjective
getValue -> getvalue

Now this example should pass the JuMP test without deprecated warnings.