### PR TITLE
implement MathProgBase.getobjbound

### DIFF
--- a/src/KnitroSolverInterface.jl
+++ b/src/KnitroSolverInterface.jl
@@ -250,6 +250,7 @@ function status(m::KnitroMathProgModel)
 end
 
 getobjval(m::KnitroMathProgModel) = m.inner.obj_val[1]
+getobjbound(m::KnitroMathProgModel) = get_mip_relaxation_bnd(m.inner)
 getsolution(m::KnitroMathProgModel) = m.inner.x
 getconstrsolution(m::KnitroMathProgModel) = m.inner.g
 getreducedcosts(m::KnitroMathProgModel) =


### PR DESCRIPTION
I'm running some benchmarks with Knitro as a MINLP solver, so useful to have the gap information.