### PR TITLE
fixed warnings

### DIFF
--- a/examples/jump_hs035_options.jl
+++ b/examples/jump_hs035_options.jl
@@ -13,8 +13,8 @@ for m in [Model(solver=KnitroSolver()),
                             + 2.0*x[1]*x[2] + 2.0*x[1]*x[3])
     @constraint(m, x[1] + x[2] + 2.0*x[3] <= 3)
     solve(m)
-    @test_approx_eq_eps getvalue(x[1]) 1.3333333 1e-5
-    @test_approx_eq_eps getvalue(x[2]) 0.7777777 1e-5
-    @test_approx_eq_eps getvalue(x[3]) 0.4444444 1e-5
-    @test_approx_eq_eps getobjectivevalue(m) 0.1111111 1e-5
+    @test getvalue(x[1]) ≈ 1.3333333 atol=1.0e-5
+    @test getvalue(x[2]) ≈ 0.7777777 atol=1.0e-5
+    @test getvalue(x[3]) ≈ 0.4444444 atol=1.0e-5
+    @test getobjectivevalue(m) ≈ 0.1111111 atol=1.0e-5
 end

--- a/examples/jump_warmstart.jl
+++ b/examples/jump_warmstart.jl
@@ -2,11 +2,11 @@ using KNITRO, JuMP, Base.Test
 
 m = Model(solver=KnitroSolver())
 @variable(m, x)
-setValue(x, 5)
+setvalue(x, 5)
 @NLobjective(m, Min, -log(x)+x^2)
 solve(m)
-@test_approx_eq_eps getobjectivevalue(m) 0.84657 1e-5
-@test_approx_eq_eps getvalue(x) 0.707107 1e-5
+@test getobjectivevalue(m) ≈ 0.84657 atol=1.0e-5
+@test getvalue(x) ≈ 0.707107 atol=1.0e-5
 
 ktrmod = internalmodel(m)
 MathProgBase.freemodel!(ktrmod)

--- a/examples/qcqp_reversecomm.jl
+++ b/examples/qcqp_reversecomm.jl
@@ -36,7 +36,7 @@ function eval_jac_g(x::Vector{Float64}, jac::Vector{Float64})
     jac[1] =  8.0
     jac[2] = 14.0
     jac[3] =  7.0
-        
+
     #---- GRADIENT OF THE SECOND CONSTRAINT, c[1].
     jac[4] = 2.0*x[1]
     jac[5] = 2.0*x[2]
@@ -98,11 +98,11 @@ initializeProblem(kp, objGoal, objType, x_L, x_U, c_Type, c_L, c_U,
 @fact kp.eval_status --> @compat(Int32(0))
 
 #---- ALLOCATE ARRAYS FOR REVERSE COMMUNICATIONS OPERATION.
-cons = Array(Float64, m)
-objGrad = Array(Float64, n)
-jac = Array(Float64, length(jac_con))
-hess = Array(Float64, length(hess_row))
-hessVector = Array(Float64, n)
+cons = Array{Float64}(m)
+objGrad = Array{Float64}(n)
+jac = Array{Float64}(length(jac_con))
+hess = Array{Float64}(length(hess_row))
+hessVector = Array{Float64}(n)
 
 #---- SOLVE THE PROBLEM.  IN REVERSE COMMUNICATIONS MODE, KNITRO
 #---- RETURNS WHENEVER IT NEEDS MORE PROBLEM INFORMATION.  THE CALLING

--- a/src/KNITRO.jl
+++ b/src/KNITRO.jl
@@ -102,7 +102,7 @@ module KNITRO
     function initializeProblem(kp, objGoal, objType, x_l, x_u, c_Type, g_lb,
                                g_ub, jac_var, jac_con; initial_x = C_NULL,
                                initial_lambda = C_NULL)
-        hessopt = Array(Int32, 1)
+        hessopt = Array{Int32}(1)
         getOption(kp, "hessopt", hessopt)
         @assert hessopt[1] != KTR_HESSOPT_EXACT
         # KNITRO documentation:

--- a/src/KnitroSolverInterface.jl
+++ b/src/KnitroSolverInterface.jl
@@ -44,7 +44,7 @@ type KnitroMathProgModel <: AbstractNonlinearModel
     function KnitroMathProgModel(;options...)
         new(options)
     end
-end 
+end
 
 NonlinearModel(s::KnitroSolver) = KnitroMathProgModel(;s.options...)
 LinearQuadraticModel(s::KnitroSolver) = NonlinearToLPQPBridge(NonlinearModel(s))
@@ -84,12 +84,12 @@ function loadproblem!(m::KnitroMathProgModel,
         Ihess = Int[]
         Jhess = Int[]
     end
-   
+
     Ijac, Jjac = jac_structure(d)
     m.nnzJ = length(Ijac)
     m.nnzH = length(Ihess)
-    jac_tmp = Array(Float64, m.nnzJ)
-    hess_tmp = Array(Float64, m.nnzH)
+    jac_tmp = Array{Float64}(m.nnzJ)
+    hess_tmp = Array{Float64}(m.nnzH)
     @assert length(Ijac) == length(Jjac)
     @assert length(Ihess) == length(Jhess)
     m.jac_con, m.jac_var, jac_indices = sparse_merge_jac_duplicates(Ijac, Jjac,
@@ -207,9 +207,9 @@ function loadproblem!(m::KnitroMathProgModel,
             end
         end
     end
-    
-    # check and define default hessian option 
-    if (!has_hessian && !defined_hessopt) || (!has_hessian && !in(hessopt_value,2:6)) 
+
+    # check and define default hessian option
+    if (!has_hessian && !defined_hessopt) || (!has_hessian && !in(hessopt_value,2:6))
         setOption(m.inner,paramName2Indx["KTR_PARAM_HESSOPT"],6)
     end
 


### PR DESCRIPTION
I fixed all of the warnings, but there is a test error that needs to be fixed before this package is tagged
```
===============================================================================

ERROR: LoadError: LoadError: Unsupported feature Jac
Stacktrace:
 [1] initialize(::Rosenbrock, ::Array{Symbol,1}) at /home/febbo/.julia/v0.6/MathProgBase/test/nlp.jl:272
 [2] loadproblem!(::KNITRO.KnitroMathProgModel, ::Int64, ::Int64, ::Array{Float64,1}, ::Array{Float64,1}, ::Array{Float64,1}, ::Array{Float64,1}, ::Symbol, ::Rosenbrock) at /home/febbo/.julia/v0.6/KNITRO/src/KnitroSolverInterface.jl:80
 [3] rosenbrocktest(::KNITRO.KnitroSolver) at /home/febbo/.julia/v0.6/MathProgBase/test/nlp.jl:308
 [4] include_from_node1(::String) at ./loading.jl:569
 [5] include(::String) at ./sysimg.jl:14
 [6] include_from_node1(::String) at ./loading.jl:569
 [7] include(::String) at ./sysimg.jl:14
 [8] process_options(::Base.JLOptions) at ./client.jl:305
 [9] _start() at ./client.jl:371
while loading /home/febbo/.julia/v0.6/KNITRO/test/mathprogtest.jl, in expression starting on line 3
while loading /home/febbo/.julia/v0.6/KNITRO/test/runtests.jl, in expression starting on line 2
=====================================================================================================================================[ ERROR: KNITRO ]=====================================================================================================================================

failed process: Process(`/opt/julia-903644385b/bin/julia -Cx86-64 -J/opt/julia-903644385b/lib/julia/sys.so --compile=yes --depwarn=yes --check-bounds=yes --code-coverage=none --color=yes --compilecache=yes /home/febbo/.julia/v0.6/KNITRO/test/runtests.jl`, ProcessExited(1)) [1]

```
`