### PR TITLE
Fix garbage collector when using license manager from JuMP

### DIFF
--- a/examples/jump_licensemanager.jl
+++ b/examples/jump_licensemanager.jl
@@ -1,4 +1,4 @@
-# Test JuMP in AUTOMATIC and DIRECT modes.
+# Test calling Knitro with license manager
 
 using KNITRO, JuMP
 using Test
@@ -14,12 +14,15 @@ const MOI = MathOptInterface
 # Start at (1,5,5,1)
 # End at (1.000..., 4.743..., 3.821..., 1.379...)
 
-# Create JuMP Model in direct mode.
-model1 = JuMP.direct_model(KNITRO.Optimizer())
-# Create JuMP Model in automatic mode.
-model2 = Model(with_optimizer(KNITRO.Optimizer))
+# Instantiate license manager
+lm = KNITRO.LMcontext()
 
-for model in [model1, model2]
+nruns = 10
+
+for i in 1:nruns
+    model = Model(with_optimizer(KNITRO.Optimizer, license_manager=lm, outlev=0))
+    #= model = JuMP.direct_model(KNITRO.Optimizer(license_manager=lm, outlev=0)) =#
+
     initval = [1, 5, 5, 1]
 
     @variable(model, 1 <= x[i=1:4] <= 5, start=initval[i])
@@ -28,11 +31,11 @@ for model in [model1, model2]
     c2 = @NLconstraint(model, sum(x[i]^2 for i=1:4) == 40)
 
     JuMP.optimize!(model)
-
-    @test JuMP.has_values(model)
     @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
-    @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
 
-    @test JuMP.value.(x) ≈ [1.000000, 4.742999, 3.821150, 1.379408] atol=1e-3
-    println("#"^80)
+    # Warning! Free Knitro model before freeing license manager!
+    MOI.empty!(model.moi_backend)
 end
+
+# Free license manager
+KNITRO.KN_release_license(lm)

--- a/examples/jump_licensemanager.jl
+++ b/examples/jump_licensemanager.jl
@@ -21,7 +21,6 @@ nruns = 10
 
 for i in 1:nruns
     model = Model(with_optimizer(KNITRO.Optimizer, license_manager=lm, outlev=1))
-    #= model = JuMP.direct_model(KNITRO.Optimizer(license_manager=lm, outlev=1)) =#
 
     initval = [1, 5, 5, 1]
 

--- a/examples/jump_licensemanager.jl
+++ b/examples/jump_licensemanager.jl
@@ -20,8 +20,8 @@ lm = KNITRO.LMcontext()
 nruns = 10
 
 for i in 1:nruns
-    model = Model(with_optimizer(KNITRO.Optimizer, license_manager=lm, outlev=0))
-    #= model = JuMP.direct_model(KNITRO.Optimizer(license_manager=lm, outlev=0)) =#
+    model = Model(with_optimizer(KNITRO.Optimizer, license_manager=lm, outlev=1))
+    #= model = JuMP.direct_model(KNITRO.Optimizer(license_manager=lm, outlev=1)) =#
 
     initval = [1, 5, 5, 1]
 

--- a/examples/jump_licensemanager.jl
+++ b/examples/jump_licensemanager.jl
@@ -33,7 +33,7 @@ for i in 1:nruns
     @test JuMP.termination_status(model) == MOI.LOCALLY_SOLVED
 
     # Warning! Free Knitro model before freeing license manager!
-    MOI.empty!(model.moi_backend)
+    MOI.empty!(backend(model))
 end
 
 # Free license manager

--- a/examples/moi_nlp1.jl
+++ b/examples/moi_nlp1.jl
@@ -124,3 +124,6 @@ KNITRO.KN_set_param(solver.inner, KNITRO.KN_PARAM_DERIVCHECK, KNITRO.KN_DERIVCHE
 # Return status codes are defined in "knitro.h" and described
 # in the Knitro manual.
 MOI.optimize!(solver)
+
+# Free solver environment properly
+MOI.empty!(solver)

--- a/src/kn_env.jl
+++ b/src/kn_env.jl
@@ -1,37 +1,6 @@
 # KNITRO environment & context
 
 #--------------------------------------------------
-# LM license manager
-#--------------------------------------------------
-"""
-Type declaration for the Artelys License Manager context object.
-Applications must not modify any part of the context.
-"""
-mutable struct LMcontext
-    ptr_lmcontext::Ptr{Cvoid}
-
-    function LMcontext()
-        ptrref = Ref{Ptr{Cvoid}}()
-        res = @kn_ccall(checkout_license, Cint, (Ptr{Cvoid},), ptrref)
-        if res != 0
-            error("KNITRO: Error checkout license")
-        end
-        lm = new(ptrref[])
-        finalizer(KN_release_license, lm)
-        return lm
-    end
-end
-
-function KN_release_license(lm::LMcontext)
-    if lm.ptr_lmcontext != C_NULL
-        refptr = Ref{Ptr{Cvoid}}(lm.ptr_lmcontext)
-        @kn_ccall(release_license, Cint, (Ptr{Cvoid},), refptr)
-        lm.ptr_lmcontext = C_NULL
-    end
-end
-
-
-#--------------------------------------------------
 # KN_context
 #--------------------------------------------------
 "Wrapper for KNITRO KN_context."
@@ -46,14 +15,8 @@ mutable struct Env
         end
         new(ptrptr_env[])
     end
-    function Env(lm::LMcontext)
-        ptrptr_env = Ref{Ptr{Cvoid}}()
-        res = @kn_ccall(new_lm, Cint, (Ptr{Cvoid},Ptr{Cvoid}), lm.ptr_lmcontext, ptrptr_env)
-        if res != 0
-            error("Fail to retrieve a valid KNITRO KN_context. Error $res")
-        end
-        new(ptrptr_env[])
-    end
+
+    Env(ptr::Ptr{Cvoid}) = new(ptr)
 end
 
 Base.unsafe_convert(ptr::Type{Ptr{Cvoid}}, env::Env) = env.ptr_env::Ptr{Cvoid}

--- a/src/kn_env.jl
+++ b/src/kn_env.jl
@@ -16,8 +16,9 @@ mutable struct LMcontext
         if res != 0
             error("KNITRO: Error checkout license")
         end
-
-        return new(ptrref[])
+        lm = new(ptrref[])
+        finalizer(KN_release_license, lm)
+        return lm
     end
 end
 

--- a/src/kn_model.jl
+++ b/src/kn_model.jl
@@ -24,12 +24,7 @@ mutable struct Model
         finalizer(KN_free, model)
         return model
     end
-    # create Model with license manager
-    function Model(lm::LMcontext)
-        model = new(Env(lm), Dict())
-        finalizer(KN_free, model)
-        return model
-    end
+    Model(env::Env, options::Dict) = new(env, options)
 end
 
 "Free solver object."
@@ -37,10 +32,8 @@ KN_free(m::Model) = free_env(m.env)
 
 "Create solver object."
 KN_new() = Model()
-KN_new_lm(lm::LMcontext) = Model(lm)
 
 is_valid(m::Model) = is_valid(m.env)
-
 
 
 ##################################################
@@ -80,4 +73,64 @@ function KN_load_mps_file(m::Model, filename::AbstractString)
     ret = @kn_ccall(load_mps_file, Cint, (Ptr{Cvoid}, Ptr{Cchar}),
                     m.env, filename)
     _checkraise(ret)
+end
+
+
+##################################################
+# LM license manager
+##################################################
+"""
+Type declaration for the Artelys License Manager context object.
+Applications must not modify any part of the context.
+"""
+mutable struct LMcontext
+    ptr_lmcontext::Ptr{Cvoid}
+    # Keep a pointer to instantiated models in order to free
+    # memory properly.
+    linked_models::Vector{Model}
+
+    function LMcontext()
+        ptrref = Ref{Ptr{Cvoid}}()
+        res = @kn_ccall(checkout_license, Cint, (Ptr{Cvoid},), ptrref)
+        if res != 0
+            error("KNITRO: Error checkout license")
+        end
+        lm = new(ptrref[], Model[])
+        finalizer(KN_release_license, lm)
+        return lm
+    end
+end
+
+function Env(lm::LMcontext)
+    ptrptr_env = Ref{Ptr{Cvoid}}()
+    res = @kn_ccall(new_lm, Cint, (Ptr{Cvoid},Ptr{Cvoid}), lm.ptr_lmcontext, ptrptr_env)
+    if res != 0
+        error("Fail to retrieve a valid KNITRO KN_context. Error $res")
+    end
+    Env(ptrptr_env[])
+end
+
+function attach!(lm::LMcontext, model::Model)
+    push!(lm.linked_models, model)
+    return
+end
+
+# create Model with license manager
+function Model(lm::LMcontext)
+    model = Model(Env(lm), Dict())
+    attach!(lm, model)
+    return model
+end
+KN_new_lm(lm::LMcontext) = Model(lm)
+
+function KN_release_license(lm::LMcontext)
+    # First, ensure that all linked models are properly freed
+    # before releasing license manager!
+    KN_free.(lm.linked_models)
+
+    if lm.ptr_lmcontext != C_NULL
+        refptr = Ref{Ptr{Cvoid}}(lm.ptr_lmcontext)
+        @kn_ccall(release_license, Cint, (Ptr{Cvoid},), refptr)
+        lm.ptr_lmcontext = C_NULL
+    end
 end


### PR DESCRIPTION
Current version of Knitro does not ensure that all Knitro's models are freed before releasing the license manager. It implies unsafe behavior when using JuMP (such as segfault). 

@kaarthiksundar:This PR adds official supports to use Knitro's license manager inside JuMP. 

