### PR TITLE
Add proper support of SOC constraints in Knitro 

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -30,18 +30,21 @@ const MOIU = MathOptInterface.Utilities
 
 const SF = Union{MOI.ScalarAffineFunction{Float64},
                  MOI.ScalarQuadraticFunction{Float64}}
+const VAF = MOI.VectorAffineFunction{Float64}
+const VOV = MOI.VectorOfVariables
 
 const SS = Union{MOI.EqualTo{Float64},
                  MOI.GreaterThan{Float64},
                  MOI.LessThan{Float64},
-                 MOI.Interval{Float64},
-                 MOI.Zeros,
-                 MOI.Nonnegatives,
-                 MOI.Nonpositives}
-
-const VS = Union{MOI.EqualTo{Float64},
+                 MOI.Interval{Float64}}
+# LinSets
+const LS = Union{MOI.EqualTo{Float64},
                  MOI.GreaterThan{Float64},
                  MOI.LessThan{Float64}}
+# VecLinSets
+const VLS = Union{MOI.Nonnegatives,
+                  MOI.Nonpositives,
+                  MOI.Zeros}
 
 ##################################################
 # Define custom error for MOI wrapper.

--- a/src/MOI_wrapper/constraints.jl
+++ b/src/MOI_wrapper/constraints.jl
@@ -227,10 +227,9 @@ function MOI.add_constraint(model::Optimizer,
     return ci
 end
 
-# add second order cone constraint
+# Add second order cone constraint.
 function MOI.add_constraint(model::Optimizer,
                             func::MOI.VectorAffineFunction, set::MOI.SecondOrderCone)
-    @warn("Support of MOI.SecondOrderCone is still experimental")
     (model.number_solved >= 1) && throw(AddConstraintError())
     # Add constraints inside KNITRO.
     index_con = KN_add_con(model.inner)
@@ -298,7 +297,6 @@ end
 
 function MOI.add_constraint(model::Optimizer,
                             func::MOI.VectorOfVariables, set::MOI.SecondOrderCone)
-    @warn("Support of MOI.SecondOrderCone is still experimental")
     (model.number_solved >= 1) && throw(AddConstraintError())
     # Add constraints inside KNITRO.
     index_con = KN_add_con(model.inner)

--- a/src/MOI_wrapper/constraints.jl
+++ b/src/MOI_wrapper/constraints.jl
@@ -17,25 +17,26 @@ MOI.supports_constraint(::Optimizer, ::Type{MOI.ScalarQuadraticFunction{Float64}
 MOI.supports_constraint(::Optimizer, ::Type{MOI.ScalarQuadraticFunction{Float64}}, ::Type{MOI.EqualTo{Float64}}) = true
 MOI.supports_constraint(::Optimizer, ::Type{<:SF}, ::Type{<:SS}) = true
 MOI.supports_constraint(::Optimizer, ::Type{MOI.SingleVariable}, ::Type{<:LS}) = true
-MOI.supports_constraint(::Optimizer, ::Type{MOI.VectorAffineFunction{Float64}}, ::Type{MOI.Nonnegatives}) = true
-MOI.supports_constraint(::Optimizer, ::Type{MOI.VectorAffineFunction{Float64}}, ::Type{MOI.Zeros}) = true
-MOI.supports_constraint(::Optimizer, ::Type{MOI.VectorAffineFunction{Float64}}, ::Type{MOI.Nonpositives}) = true
-MOI.supports_constraint(::Optimizer, ::Type{MOI.VectorAffineFunction{Float64}}, ::Type{MOI.SecondOrderCone}) = true
-MOI.supports_constraint(::Optimizer, ::Type{MOI.VectorOfVariables}, ::Type{MOI.SecondOrderCone}) = true
+MOI.supports_constraint(::Optimizer, ::Type{VAF}, ::Type{<:VLS}) = true
+MOI.supports_constraint(::Optimizer, ::Type{VOV}, ::Type{<:VLS}) = true
+MOI.supports_constraint(::Optimizer, ::Type{VAF}, ::Type{MOI.SecondOrderCone}) = true
+MOI.supports_constraint(::Optimizer, ::Type{VOV}, ::Type{MOI.SecondOrderCone}) = true
 
 ##################################################
 ## Getters
 MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{MOI.SingleVariable, MOI.ZeroOne}) =
     model.number_zeroone_constraints
 # TODO: a bit hacky, but that should work for MOI Test.
-MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}) =
-sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives})
-MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonpositives}) =
-sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.Nonpositives})
-MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Zeros}) =
-sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.Zeros})
-MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone}) =
-sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone})
+MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{VAF, MOI.Nonnegatives}) =
+sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{VAF, MOI.Nonnegatives})
+MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{VAF, MOI.Nonpositives}) =
+sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{VAF, MOI.Nonpositives})
+MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{VAF, MOI.Zeros}) =
+sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{VAF, MOI.Zeros})
+MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{VAF, MOI.SecondOrderCone}) =
+sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{VAF, MOI.SecondOrderCone})
+MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{VOV, T}) where T <: VLS =
+sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{VAF, T})
 
 MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, S}) where S <: LS  =
 sum(typeof.(collect(keys(model.constraint_mapping))) .== MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, S})
@@ -269,6 +270,26 @@ function MOI.add_constraint(model::Optimizer,
     # Add constraints to index.
     ci = MOI.ConstraintIndex{typeof(func), typeof(set)}(index_con)
     model.constraint_mapping[ci] = indexvars
+    return ci
+end
+
+function MOI.add_constraint(model::Optimizer, func::VOV, set::T) where T <: VLS
+    (model.number_solved >= 1) && throw(AddConstraintError())
+    indv = convert.(Cint, [v.value for v in func.variables] .- 1)
+    bnd = zeros(Float64, length(indv))
+
+    if isa(set, MOI.Zeros)
+        KN_set_var_fxbnds(model.inner, indv, bnd)
+    elseif isa(set, MOI.Nonnegatives)
+        KN_set_var_lobnds(model.inner, indv, bnd)
+    elseif isa(set, MOI.Nonpositives)
+        KN_set_var_upbnds(model.inner, indv, bnd)
+    end
+
+    # TODO
+    ncons = MOI.get(model, MOI.NumberOfConstraints{VOV, T}())
+    ci = MOI.ConstraintIndex{VOV, T}(ncons)
+    model.constraint_mapping[ci] = indv
     return ci
 end
 

--- a/src/MOI_wrapper/constraints.jl
+++ b/src/MOI_wrapper/constraints.jl
@@ -24,6 +24,8 @@ MOI.supports_constraint(::Optimizer, ::Type{VOV}, ::Type{MOI.SecondOrderCone}) =
 
 ##################################################
 ## Getters
+MOI.get(model::Optimizer, ::MOI.NumberOfConstraints) =
+    KN_get_number_cons(model.inner)
 MOI.get(model::Optimizer, ::MOI.NumberOfConstraints{MOI.SingleVariable, MOI.ZeroOne}) =
     model.number_zeroone_constraints
 # TODO: a bit hacky, but that should work for MOI Test.
@@ -300,7 +302,7 @@ function MOI.add_constraint(model::Optimizer,
     (model.number_solved >= 1) && throw(AddConstraintError())
     # Add constraints inside KNITRO.
     index_con = KN_add_con(model.inner)
-    indv = [v.value for v in func.variables] .- 1
+    indv = [v.value - 1 for v in func.variables]
 
     KN_set_con_upbnd(model.inner, index_con, 0.)
     KN_add_con_linear_struct(model.inner, index_con, indv[1], -1.0)

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -148,9 +148,9 @@ end
 
 function MOI.get(model::Optimizer, ::MOI.ConstraintPrimal,
                  ci::MOI.ConstraintIndex{S, T}) where {S <: VAF, T <: Union{MOI.Nonnegatives, MOI.Nonpositives}}
+    @warn("Support for MOI getter for MOI.Nonpositives and Nonnegatives constraints is still experimental in Knitro")
     @checkcons(model, ci)
     g = KN_get_con_values(model.inner)
-
     index = model.constraint_mapping[ci] .+ 1
     return g[index]
 end
@@ -165,6 +165,7 @@ end
 
 function MOI.get(model::Optimizer, ::MOI.ConstraintPrimal,
                  ci::MOI.ConstraintIndex{S, T}) where {S <: Union{VAF, VOV}, T <: MOI.Zeros}
+    @warn("Support for MOI getter for MOI.Zeros constraints is still experimental in Knitro")
     @checkcons(model, ci)
     ncons = length(model.constraint_mapping[ci])
     return zeros(ncons)
@@ -250,11 +251,11 @@ end
 #
 # Use the following mathematical property.  Let
 #
-# ||u_i || <= t_i      with dual associated constraint    || z_i || <= w_i
+#   ||u_i || <= t_i      with dual constraint    || z_i || <= w_i
 #
 # At optimality, we have
 #
-# w_i * u_i  = - t_i z_i
+#   w_i * u_i  = - t_i z_i
 #
 ###
 function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
@@ -263,7 +264,6 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
     index_var = model.constraint_mapping[ci] .+ 1
     index_con = ci.value
     x =  get_solution(model.inner)[index_var]
-    println(x)
     # By construction.
     t_i = x[1]
     u_i = x[2:end]

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -147,6 +147,14 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintPrimal,
 end
 
 function MOI.get(model::Optimizer, ::MOI.ConstraintPrimal,
+                 ci::MOI.ConstraintIndex{S, T}) where {S <: VOV, T <: Union{MOI.Nonnegatives, MOI.Nonpositives}}
+    @checkcons(model, ci)
+    x = get_solution(model.inner)
+    index = model.constraint_mapping[ci] .+ 1
+    return x[index]
+end
+
+function MOI.get(model::Optimizer, ::MOI.ConstraintPrimal,
                  ci::MOI.ConstraintIndex{S, T}) where {S <: Union{VAF, VOV}, T <: MOI.Zeros}
     @checkcons(model, ci)
     ncons = length(model.constraint_mapping[ci])
@@ -230,11 +238,18 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
 end
 
 function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
+                 ci::MOI.ConstraintIndex{S, T}) where {S <: VOV, T <: VLS}
+    offset = number_constraints(model)
+    index = model.constraint_mapping[ci] .+ 1 .+ offset
+    lambda = get_dual(model.inner)
+    return sense_dual(model) * lambda[index]
+end
+
+function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
                  ci::MOI.ConstraintIndex{S, T}) where {S <: Union{VAF, VOV}, T <: MOI.SecondOrderCone}
     @checkcons(model, ci)
     index = model.constraint_mapping[ci] .+ 1
     lambda = get_dual(model.inner)
-    println(lambda)
     return sense_dual(model) * lambda[index]
 end
 

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -1,0 +1,140 @@
+# Extend MathOptInterface Test for Knitro.
+#
+# This file is largely adapted from :
+# MathOptInterface/src/Tests/contconic.jl
+# https://github.com/JuliaOpt/MathOptInterface.jl/blob/master/src/Test/contconic.jl
+#
+# LICENSE:
+# MIT "expat" license
+# Copyright (c) 2017: Miles Lubin and contributors Copyright (c) 2017: Google Inc.
+
+using MathOptInterface
+
+const MOI = MathOptInterface
+
+const CONIC_OPTIMIZER = KNITRO.Optimizer(outlev=0, presolve=0, opttol=1e-8)
+
+@testset "MOI SOCP 1" begin
+    # Derived from MOI's problem SOC1
+    model = MOIU.CachingOptimizer(KnitroModelData{Float64}(), CONIC_OPTIMIZER)
+    atol = 1e-4
+    rtol = 1e-4
+
+    # Problem SOC1
+    # max 0x + 1y + 1z
+    #  st  x            == 1
+    #      x >= ||(y,z)||
+
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    @test MOI.supports_constraint(model, MOI.VectorOfVariables,MOI.SecondOrderCone)
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    x,y,z = MOI.add_variables(model, 3)
+
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [y,z]), 0.0))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+
+    ceq = MOI.add_constraint(model,
+                             MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Zeros(1))
+    vov = MOI.VectorOfVariables([x,y,z])
+    csoc = MOI.add_constraint(model,
+                              MOI.VectorAffineFunction{Float64}(vov), MOI.SecondOrderCone(3))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+    loc = MOI.get(model, MOI.ListOfConstraints())
+    @test length(loc) == 2
+    @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
+    @test (MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone) in loc
+
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+    MOI.optimize!(model)
+
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.LOCALLY_SOLVED
+
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+    @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
+
+    @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol=atol rtol=rtol
+
+    @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+    @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/√2 atol=atol rtol=rtol
+    @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 1/√2 atol=atol rtol=rtol
+
+    @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.] atol=atol rtol=rtol
+    @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈ [1., 1/√2, 1/√2] atol=atol rtol=rtol
+
+    @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [-√2] atol=atol rtol=rtol
+    @test MOI.get(model, MOI.ConstraintDual(), csoc) ≈ [√2, -1.0, -1.0] atol=atol rtol=rtol
+end
+
+MOI.empty!(CONIC_OPTIMIZER)
+
+@testset "MOI SOCP 2" begin
+    model = MOIU.CachingOptimizer(KnitroModelData{Float64}(), CONIC_OPTIMIZER)
+    atol = 1e-4
+    rtol = 1e-4
+    # Problem SOC2
+    # min  x
+    # s.t. y ≥ 1/√2
+    #      x² + y² ≤ 1
+    # in conic form:
+    # min  x
+    # s.t.  -1/√2 + y ∈ R₊
+    #        1 - t ∈ {0}
+    #      (t,x,y) ∈ SOC₃
+
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    x,y,t = MOI.add_variables(model, 3)
+
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+
+    cnon = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(-1.0, y))], [1/√2]), MOI.Nonpositives(1))
+    ceq = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(-1.0, t))], [1.0]), MOI.Zeros(1))
+    csoc = MOI.add_constraint(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,2,3], MOI.ScalarAffineTerm.(1.0, [t,x,y])), zeros(3)), MOI.SecondOrderCone(3))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonpositives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+    MOI.optimize!(model)
+
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.LOCALLY_SOLVED
+
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+    @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
+
+    @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1/√2 atol=atol rtol=rtol
+
+    @test MOI.get(model, MOI.VariablePrimal(), x) ≈ -1/√2 atol=atol rtol=rtol
+    @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/√2 atol=atol rtol=rtol
+    @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
+
+    # Getter of Nonnegatives constraints is currently broken!!
+    @test_broken MOI.get(model, MOI.ConstraintPrimal(), cnon) ≈ [0.0] atol=atol rtol=rtol
+    @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.0] atol=atol rtol=rtol
+    @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈ [1., -1/√2, 1/√2] atol=atol rtol=rtol
+
+    @test MOI.get(model, MOI.ConstraintDual(), cnon) ≈ [-1.0] atol=atol rtol=rtol
+    @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [√2] atol=atol rtol=rtol
+    @test MOI.get(model, MOI.ConstraintDual(), csoc) ≈ [√2, 1.0, -1.0] atol=atol rtol=rtol
+end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -34,36 +34,25 @@ const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4,
     MOIT.contlineartest(linear_optimizer, config, exclude)
 end
 
-
 @testset "MOI QP/QCQP tests" begin
     optimizer = KNITRO.Optimizer(outlev=0)
     qp_optimizer = MOIU.CachingOptimizer(KnitroModelData{Float64}(), optimizer)
     MOIT.contquadratictest(qp_optimizer, config)
 end
 
+@testset "MOI SOCP tests" begin
+    # Presolve must be switch off to get proper dual variables.
+    optimizer = KNITRO.Optimizer(outlev=0, presolve=0)
+    socp_optimizer = MOIU.CachingOptimizer(KnitroModelData{Float64}(), optimizer)
+    # Behavior in infeasible case doesn't match test.
+    exclude = ["lin3", "lin4"]
+    MOIT.lintest(socp_optimizer, config, exclude)
+end
 
 @testset "MOI NLP tests" begin
     optimizer = KNITRO.Optimizer(outlev=0)
     MOIT.nlptest(optimizer, config)
 end
-
-
-@testset "MOI SOCP tests" begin
-    # Warning: set presolve to 0 to avoid bug in Knitro.
-    optimizer = KNITRO.Optimizer(outlev=0, opttol=1e-8, presolve=0)
-    socp_optimizer = MOIU.CachingOptimizer(KnitroModelData{Float64}(), optimizer)
-    # Behavior in infeasible case doesn't match test.
-    exclude = ["lin3", "lin4"]
-    MOIT.lintest(socp_optimizer, config, exclude)
-
-    # Support of SOC's duals is not enabled.
-    configcone = MOIT.TestConfig(atol=1e-4, rtol=1e-4, duals=false,
-                                 optimal_status=MOI.LOCALLY_SOLVED)
-    # Behavior in infeasible case doesn't match test.
-    exclude = ["soc3", "soc4"]
-    MOIT.soctest(socp_optimizer, configcone, exclude)
-end
-
 
 @testset "MOI MILP test" begin
     optimizer = KNITRO.Optimizer(outlev=0)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -20,8 +20,7 @@ const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4,
                                optimal_status=MOI.LOCALLY_SOLVED)
 
 @testset "MOI Linear tests" begin
-    # to check unbounded problem, change the default algorithm used
-    # by KNITRO
+    # To check unbounded problem, change the default algorithm used by KNITRO.
     optimizer = KNITRO.Optimizer(outlev=0, algorithm=3)
 
     exclude = ["linear8a", # Behavior in infeasible case doesn't match test.
@@ -47,12 +46,22 @@ end
 end
 
 
-# Currently SOCP test returns segfault ...
-#= @testset "MOI SOCP tests" begin =#
-    #= socp_optimizer = MOIU.CachingOptimizer(KnitroModelData{Float64}(), optimizer) =#
-    #= MOI.supports_constraint(::KNITRO.Optimizer, ::Type{MOI.VectorOfVariables}, ::Type{MOI.SecondOrderCone}) = true =#
-    #= MOIT._soc1test(socp_optimizer, config, false) =#
-#= end =#
+@testset "MOI SOCP tests" begin
+    # Warning: set presolve to 0 to avoid bug in Knitro.
+    optimizer = KNITRO.Optimizer(outlev=0, opttol=1e-8, presolve=0)
+    socp_optimizer = MOIU.CachingOptimizer(KnitroModelData{Float64}(), optimizer)
+    # Behavior in infeasible case doesn't match test.
+    exclude = ["lin3", "lin4"]
+    MOIT.lintest(socp_optimizer, config, exclude)
+
+    # Support of SOC's duals is not enabled.
+    configcone = MOIT.TestConfig(atol=1e-4, rtol=1e-4, duals=false,
+                                 optimal_status=MOI.LOCALLY_SOLVED)
+    # Behavior in infeasible case doesn't match test.
+    exclude = ["soc3", "soc4"]
+    MOIT.soctest(socp_optimizer, configcone, exclude)
+end
+
 
 @testset "MOI MILP test" begin
     optimizer = KNITRO.Optimizer(outlev=0)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -25,6 +25,7 @@ const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4,
 
     exclude = ["linear8a", # Behavior in infeasible case doesn't match test.
                "linear12", # Same as above.
+               "linear14", # TODO
                "linear8c", # Problem catching infeasibility ray
                ]
     model_for_knitro = MOIU.UniversalFallback(KnitroModelData{Float64}())

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 JuMP
+MathProgBase

--- a/test/jump_soc.jl
+++ b/test/jump_soc.jl
@@ -1,7 +1,17 @@
+# Adaptation of some examples in MosekTools
+# Refer to:
+# https://github.com/JuliaOpt/MosekTools.jl/blob/master/test/jump_soc.jl
+#
+# MIT License
+# Copyright (c) 2017, Ulf Worsøe, Mosek Aps
+
 using JuMP
+
 @testset "Second-order Cone Programming" begin
+    solver = KNITRO.Optimizer
+
     @testset "SOC1" begin
-        m = Model(with_optimizer(solver))
+        m = Model(with_optimizer(solver, outlev=0))
         @variable(m, x)
         @variable(m, y)
         @variable(m, t >= 0)
@@ -22,7 +32,7 @@ using JuMP
     end
 
     @testset "RotatedSOC1" begin
-        m = Model(with_optimizer(solver))
+        m = Model(with_optimizer(solver, outlev=0))
 
         @variable(m, x[1:5] >= 0)
         @variable(m, 0 <= u <= 5)

--- a/test/jump_soc.jl
+++ b/test/jump_soc.jl
@@ -1,0 +1,48 @@
+using JuMP
+@testset "Second-order Cone Programming" begin
+    @testset "SOC1" begin
+        m = Model(with_optimizer(solver))
+        @variable(m, x)
+        @variable(m, y)
+        @variable(m, t >= 0)
+        @objective(m, Min, t)
+        @constraint(m, x + y >= 1)
+        @constraint(m, [t,x,y] in MOI.SecondOrderCone(3))
+
+        JuMP.optimize!(m)
+
+        @test JuMP.has_values(m)
+        @test JuMP.termination_status(m) == MOI.LOCALLY_SOLVED
+        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+
+        @test JuMP.objective_value(m) ≈ sqrt(1/2) atol=1e-6
+
+        @test JuMP.value.([x,y,t]) ≈ [0.5,0.5,sqrt(1/2)] atol=1e-3
+
+    end
+
+    @testset "RotatedSOC1" begin
+        m = Model(with_optimizer(solver))
+
+        @variable(m, x[1:5] >= 0)
+        @variable(m, 0 <= u <= 5)
+        @variable(m, v)
+        @variable(m, t1 == 1)
+        @variable(m, t2 == 1)
+
+        @objective(m, Max, v)
+
+        @constraint(m, [t1/sqrt(2),t2/sqrt(2),x...] in MOI.RotatedSecondOrderCone(7))
+        @constraint(m, [x[1]/sqrt(2), u/sqrt(2), v] in MOI.RotatedSecondOrderCone(3))
+
+        JuMP.optimize!(m)
+
+        @test JuMP.has_values(m)
+        @test JuMP.termination_status(m) == MOI.LOCALLY_SOLVED
+        @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT
+
+        @test JuMP.value.(x) ≈ [1,0,0,0,0] atol=1e-2
+        @test JuMP.value(u) ≈ 5 atol=1e-4
+        @test JuMP.value(v) ≈ sqrt(5) atol=1e-4
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,5 +18,10 @@ if KNITRO.KNITRO_VERSION >= v"11.0"
 
     @testset "Test MathOptInterface" begin
         include("MOI_wrapper.jl")
+        include("MOI_additional.jl")
+    end
+
+    @testset "Test JuMP" begin
+        include("jump_soc.jl")
     end
 end


### PR DESCRIPTION
This PR allows to pass `SecondOrderCone` constraints directly to Knitro, without cache. 

Note that, in [MOI contconic tests](https://github.com/JuliaOpt/MathOptInterface.jl/blob/master/src/Test/contconic.jl): 
- the `ConstraintPrimal` getter fails to fetch correctly the value of `Zeros` and `{Nonnegative,Nonpositive}` constraints (on [this line](https://github.com/JuliaOpt/MathOptInterface.jl/blob/master/src/Test/contconic.jl#L426) for instance)
- Allowing to pass this test would require to keep constraints RHS inside Knitro's `MOI.Optimizer` , thus adding a consequent overhead. That is why we choose to support only partially this functionnality, by adding a [warning](https://github.com/JuliaOpt/MathOptInterface.jl/blob/master/src/Test/contconic.jl). 



