### PR TITLE
Improve performance of KNITRO.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 MathProgBase 0.5 0.8
-MathOptInterface 0.8.1 0.9
+MathOptInterface 0.8.4 0.9
 Compat 1.3

--- a/examples/knitro.opt
+++ b/examples/knitro.opt
@@ -727,7 +727,7 @@ linsolver_pivottol        1e-08
 # Whether to apply a presolve operation to the model.
 #   none   = 0 = no presolve
 #   basic  = 1 = Knitro performs basic presolve
-presolve     basic
+presolve     1
 
 # Specifies the tolerance used to determine whether or not deduced bounds.
 # from the presolve operation are infeasible.

--- a/examples/lp.mps
+++ b/examples/lp.mps
@@ -1,0 +1,31 @@
+* File: lo1.mps
+NAME          lo1
+OBJSENSE
+    MAX
+ROWS
+ N  obj
+ E  c1
+ G  c2
+ L  c3
+COLUMNS
+    x1        obj       3
+    x1        c1        3
+    x1        c2        2
+    x2        obj       1
+    x2        c1        1
+    x2        c2        1
+    x2        c3        2
+    x3        obj       5
+    x3        c1        2
+    x3        c2        3
+    x4        obj       1
+    x4        c2        1
+    x4        c3        3
+RHS
+    rhs       c1        30
+    rhs       c2        15
+    rhs       c3        25
+RANGES
+BOUNDS
+ UP bound     x2        10
+ENDATA

--- a/examples/moi_nlp1.jl
+++ b/examples/moi_nlp1.jl
@@ -30,10 +30,12 @@ struct HS15 <: MOI.AbstractNLPEvaluator
 end
 
 
-MOI.features_available(d::HS15) = [:Grad]
+MOI.features_available(d::HS15) = [:Grad, :Hess]
 MOI.initialize(d::HS15, features) = nothing
 
 MOI.jacobian_structure(d::HS15) = []
+MOI.hessian_lagrangian_structure(d::HS15) = Tuple{Int64,Int64}[(1,1), (1, 2), (2, 2)]
+
 #*------------------------------------------------------------------*
 #*     FUNCTION callbackEvalF                                       *
 #*------------------------------------------------------------------*
@@ -44,7 +46,7 @@ end
 function MOI.eval_constraint(::HS15, g, x)
     nothing
 end
-function MOI.eval_constraint_jacobian(::HS15, g, x)
+function MOI.eval_constraint_jacobian(::HS15, jac_g, x)
     nothing
 end
 
@@ -63,8 +65,8 @@ end
 #*------------------------------------------------------------------*
 function MOI.eval_hessian_lagrangian(d::HS15, H, x, σ, μ)
     H[1] = σ * ((-400.0 * x[2]) + (1200.0 * x[1] * x[1]) + 2.0) #(0,0)
-    H[2] = σ * (-400.0 * x[1]) #(0,1)
-    H[3] = σ * 200.0           #(1,1)
+    H[2] = σ * (-400.0 * x[1])  #(0,1)
+    H[3] = σ * 200.0            #(1,1)
 
     return 0
 end
@@ -73,16 +75,17 @@ end
 #*     main                                                         *
 #*------------------------------------------------------------------*
 
-# Initialize Knitro
+# Initialize Knitro.
 options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
-solver = KNITRO.Optimizer(option_file=options)
+# Define a Knitro solver instance through MOI.
+solver = KNITRO.Optimizer(outlev=3, opttol=1e-8)
 lb =[]; ub=[]
 block_data = MOI.NLPBlockData(MOI.NLPBoundsPair.(lb, ub), HS15(false), true)
 
 n = 2
 v = MOI.add_variables(solver, n)
 
-u = [0.5, KNITRO.KN_INFINITY]
+u = [0.5, Inf]
 start = [-2., 1.]
 
 for i in 1:2
@@ -90,37 +93,28 @@ for i in 1:2
     MOI.set(solver, MOI.VariablePrimalStart(), v[i], start[i])
 end
 
-# Add the constraints and set their lower bounds
+# Add the constraints and set their lower bounds.
 m = 2
-# first constraint: x0 * x1 >= 1
+# First constraint: x0 * x1 >= 1.
 cf1 = MOI.ScalarQuadraticFunction{Float64}(
         MOI.ScalarAffineTerm.(0.0, v),
         [MOI.ScalarQuadraticTerm(1., v[1], v[2])],
         0.)
 c1 = MOI.add_constraint(solver, cf1, MOI.GreaterThan{Float64}(1.))
 
-# second constraint: x0 + x1^2 >= 0
+# Second constraint: x0 + x1^2 >= 0.
 cf2 = MOI.ScalarQuadraticFunction(
-                                 [MOI.ScalarAffineTerm(2.0, v[1])],
+                                 [MOI.ScalarAffineTerm(1.0, v[1])],
                                  [MOI.ScalarQuadraticTerm(1., v[2], v[2])],
                                  0.)
 c2 = MOI.add_constraint(solver, cf2, MOI.GreaterThan(0.))
 
 MOI.set(solver, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-# define NLP structure
+# Define NLP structure.
 MOI.set(solver, MOI.NLPBlock(), block_data)
 
-
-# Specify that the user is able to provide evaluations
-# of the hessian matrix without the objective component.
-# turned off by default but should be enabled if possible.
-KNITRO.KN_set_param(solver.inner, KNITRO.KN_PARAM_HESSIAN_NO_F, KNITRO.KN_HESSIAN_NO_F_ALLOW)
-
-# Perform a derivative check.
-KNITRO.KN_set_param(solver.inner, KNITRO.KN_PARAM_DERIVCHECK, KNITRO.KN_DERIVCHECK_ALL)
-
 # Solve the problem.
-#
-# Return status codes are defined in "knitro.h" and described
-# in the Knitro manual.
 MOI.optimize!(solver)
+
+# Explicitly empty model to free Knitro.
+MOI.empty!(solver)

--- a/examples/mps_reader.jl
+++ b/examples/mps_reader.jl
@@ -1,0 +1,45 @@
+#*******************************************************/
+#* Copyright(c) 2019 by Artelys                        */
+#* This source code is subject to the terms of the     */
+#* MIT Expat License (see LICENSE.md)                  */
+#*******************************************************/
+
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#  This example demonstrates how to load a MPS file with Knitro MPS
+#  reader.
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+using KNITRO
+
+# Absolute path to MPS file.
+mps_file = joinpath(dirname(@__FILE__), "..", "examples", "lp.mps")
+
+# Create a new Knitro solver instance.
+kc = KNITRO.KN_new()
+
+# Illustrate how to override default options by reading from
+# the knitro.opt file.
+options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
+KNITRO.KN_load_param_file(kc, options)
+
+# Import MPS file inside Knitro.
+err = KNITRO.KN_load_mps_file(kc, mps_file)
+
+# Solve the problem.
+# Return status codes are defined in "kn_defines.jl" and described
+# in the Knitro manual.
+nStatus = KNITRO.KN_solve(kc)
+
+println("Knitro converged with final status = ", nStatus)
+
+# An example of obtaining solution information.
+nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
+
+# Delete the Knitro solver instance.
+KNITRO.KN_free(kc)
+
+@testset "Exemple lp1" begin
+    @test nStatus == 0
+    @test objSol ≈ 250 / 3 atol=1e-5
+end

--- a/examples/multipleCB.jl
+++ b/examples/multipleCB.jl
@@ -165,7 +165,7 @@ KNITRO.KN_add_con_quadratic_struct(kc, qconIndexCons, qconIndexVars1, qconIndexV
 # Add separate callbacks.
 
 # Set callback data for nonlinear objective term.
-cbObj = KNITRO.KN_add_eval_callback(kc, callbackEvalObj)
+cbObj = KNITRO.KN_add_objective_callback(kc, callbackEvalObj)
 KNITRO.KN_set_cb_grad(kc, cbObj, callbackEvalObjGrad,
                       objGradIndexVars=xIndices, nV=length(xIndices))
 

--- a/examples/multistart.jl
+++ b/examples/multistart.jl
@@ -30,7 +30,7 @@ using KNITRO
 #*------------------------------------------------------------------*
 #*     FUNCTION callbackEvalF                                       *
 #*------------------------------------------------------------------*
-# The signature of this function matches KNITRO.KN_eval_callback in knitro.jl.
+# The signature of this function matches KN_eval_callback in knitro.jl.
 # Only "obj" is set in the KNITRO.KN_eval_result structure.
 function callbackEvalF(kc, cb, evalRequest, evalResult, userParams)
     x = evalRequest.x
@@ -45,8 +45,8 @@ end
 #*------------------------------------------------------------------*
 #*     FUNCTION callbackEvalG                                       *
 #*------------------------------------------------------------------*
-# The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
-# Only "objGrad" is set in the KNITRO.KN_eval_result structure.
+# The signature of this function matches KN_eval_callback in knitro.h.
+# Only "objGrad" is set in the KN_eval_result structure.
 function callbackEvalG!(kc, cb, evalRequest, evalResult, userParams)
     x = evalRequest.x
 
@@ -61,8 +61,8 @@ end
 #*------------------------------------------------------------------*
 #*     FUNCTION callbackEvalH                                       *
 #*------------------------------------------------------------------*
-# The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
-# Only "hess" and "hessVec" are set in the KNITRO.KN_eval_result structure.
+# The signature of this function matches KN_eval_callback in knitro.h.
+# Only "hess" and "hessVec" are set in the KN_eval_result structure.
 function callbackEvalH!(kc, cb, evalRequest, evalResult, userParams)
     x = evalRequest.x
     # Scale objective component of hessian by sigma
@@ -72,7 +72,7 @@ function callbackEvalH!(kc, cb, evalRequest, evalResult, userParams)
     # Note: Since the Hessian is symmetric, we only provide the
     #       nonzero elements in the upper triangle(plus diagonal).
     #       These are provided in row major ordering as specified
-    #       by the setting KNITRO.KN_DENSE_ROWMAJOR in "KNITRO.KN_set_cb_hess()".
+    #       by the setting KN_DENSE_ROWMAJOR in "KN_set_cb_hess()".
     # Note: The Hessian terms for the quadratic constraints
     #       will be added internally by Knitro to form
     #       the full Hessian of the Lagrangian.
@@ -146,12 +146,12 @@ KNITRO.KN_add_con_linear_struct(kc, 1, 0, 1.0)
 KNITRO.KN_add_con_quadratic_struct(kc, 1, 1, 1, 1.0)
 
 # Add a callback function "callbackEvalF" to evaluate the nonlinear
-#(non-quadratic) objective.  Note that the linear and
+# (non-quadratic) objective.  Note that the linear and
 # quadratic terms in the objective could be loaded separately
 # via "KNITRO.KN_add_obj_linear_struct()" / "KNITRO.KN_add_obj_quadratic_struct()".
 # However, for simplicity, we evaluate the whole objective
 # function through the callback.
-cb = KNITRO.KN_add_eval_callback(kc, callbackEvalF)
+cb = KNITRO.KN_add_objective_callback(kc, callbackEvalF)
 
 # Also add a callback function "callbackEvalG" to evaluate the
 # objective gradient.  If not provided, Knitro will approximate
@@ -161,12 +161,12 @@ cb = KNITRO.KN_add_eval_callback(kc, callbackEvalF)
 # We specify the objective gradient in "dense" form for simplicity.
 # However for models with many constraints, it is important to specify
 # the non-zero sparsity structure of the constraint gradients
-#(i.e. Jacobian matrix) for efficiency(this is true even when using
+# (i.e. Jacobian matrix) for efficiency(this is true even when using
 # finite-difference gradients).
 KNITRO.KN_set_cb_grad(kc, cb, callbackEvalG!)
 
 # Add a callback function "callbackEvalH" to evaluate the Hessian
-#(i.e. second derivative matrix) of the objective.  If not specified,
+# (i.e. second derivative matrix) of the objective.  If not specified,
 # Knitro will approximate the Hessian. However, providing a callback
 # for the exact Hessian(as well as the non-zero sparsity structure)
 # can greatly improve Knitro performance and is recommended if possible.
@@ -174,7 +174,7 @@ KNITRO.KN_set_cb_grad(kc, cb, callbackEvalG!)
 # Again for simplicity, we specify it in dense(row major) form.
 KNITRO.KN_set_cb_hess(kc, cb, KNITRO.KN_DENSE_ROWMAJOR, callbackEvalH!)
 
- # specify that the user is able to provide evaluations
+# Specify that the user is able to provide evaluations
 # of the hessian matrix without the objective component.
 # turned off by default but should be enabled if possible.
 KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_HESSIAN_NO_F, KNITRO.KN_HESSIAN_NO_F_ALLOW)
@@ -216,7 +216,7 @@ end
 println("Optimal constraint values(with corresponding multiplier)")
 c = KNITRO.KN_get_con_values(kc)
 for j in 1:m
-    println("  c[$j] = ", c[j], "(lambda = ",  lambda_[m+j], ")")
+    println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
 end
 println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
 println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))

--- a/examples/nlp1.jl
+++ b/examples/nlp1.jl
@@ -91,6 +91,7 @@ kc = KNITRO.KN_new()
 # the knitro.opt file.
 options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
 KNITRO.KN_load_param_file(kc, options)
+KNITRO.KN_set_param(kc, "outlev", 3)
 
 # Initialize Knitro with the problem definition.
 
@@ -102,7 +103,7 @@ n = 2
 KNITRO.KN_add_vars(kc, n)
 KNITRO.KN_set_var_lobnds(kc,  [-KNITRO.KN_INFINITY, -KNITRO.KN_INFINITY]) # not necessary since infinite
 KNITRO.KN_set_var_upbnds(kc,  [0.5, KNITRO.KN_INFINITY])
-# Define an initial point.  If not set, Knitro will generate one.
+# Define an initial point. If not set, Knitro will generate one.
 KNITRO.KN_set_var_primal_init_values(kc, [-2.0, 1.0])
 
 # Add the constraints and set their lower bounds
@@ -134,8 +135,7 @@ KNITRO.KN_add_con_quadratic_struct(kc, 1, 1, 1, 1.0)
 # via "KNITRO.KN_add_obj_linear_struct()" / "KNITRO.KN_add_obj_quadratic_struct()".
 # However, for simplicity, we evaluate the whole objective
 # function through the callback.
-#= cb = KNITRO.KN_add_eval_callback(kc, evalObj = True, funcCallback = callbackEvalF) =#
-cb = KNITRO.KN_add_eval_callback(kc, callbackEvalF)
+cb = KNITRO.KN_add_objective_callback(kc, callbackEvalF)
 
 # Also add a callback function "callbackEvalG" to evaluate the
 # objective gradient.  If not provided, Knitro will approximate
@@ -185,13 +185,13 @@ end
 println("Optimal constraint values(with corresponding multiplier)")
 c = KNITRO.KN_get_con_values(kc)
 for j in 1:m
-    println("  c[$j] = ", c[j], "(lambda = ",  lambda_[m+j], ")")
+    println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
 end
 println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
 println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 
 # Delete the Knitro solver instance.
-KNITRO.KN_free(kc)
+#= KNITRO.KN_free(kc) =#
 
 @testset "Exemple HS15 nlp1" begin
     @test nStatus == 0

--- a/examples/nlp1.jl
+++ b/examples/nlp1.jl
@@ -145,7 +145,7 @@ cb = KNITRO.KN_add_objective_callback(kc, callbackEvalF)
 # We specify the objective gradient in "dense" form for simplicity.
 # However for models with many constraints, it is important to specify
 # the non-zero sparsity structure of the constraint gradients
-#(i.e. Jacobian matrix) for efficiency(this is true even when using
+# (i.e. Jacobian matrix) for efficiency(this is true even when using
 # finite-difference gradients).
 KNITRO.KN_set_cb_grad(kc, cb, callbackEvalG!)
 

--- a/examples/nlp1noderivs.jl
+++ b/examples/nlp1noderivs.jl
@@ -66,7 +66,7 @@ n = 2
 KNITRO.KN_add_vars(kc, n)
 KNITRO.KN_set_var_lobnds(kc, [-KNITRO.KN_INFINITY, -KNITRO.KN_INFINITY]) # not necessary since infinite
 KNITRO.KN_set_var_upbnds(kc, [0.5, KNITRO.KN_INFINITY])
-# Define an initial point.  If not set, Knitro will generate one.
+# Define an initial point. If not set, Knitro will generate one.
 KNITRO.KN_set_var_primal_init_values(kc, [-2.0, 1.0])
 
 # Add the constraints and set their lower bounds
@@ -104,7 +104,7 @@ KNITRO.KN_add_con_quadratic_struct(kc, 1, 1, 1, 1.0)
 # via "KNITRO.KN_add_obj_linear_struct()" / "KNITRO.KN_add_obj_quadratic_struct()".
 # However, for simplicity, we evaluate the whole objective
 # function through the callback.
-cb = KNITRO.KN_add_eval_callback(kc, callbackEvalF)
+cb = KNITRO.KN_add_objective_callback(kc, callbackEvalF)
 
 # Set minimize or maximize(if not set, assumed minimize)
 KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MINIMIZE)
@@ -132,7 +132,7 @@ end
 println("Optimal constraint values(with corresponding multiplier)")
 c = KNITRO.KN_get_con_values(kc)
 for j in 1:m
-    println("  c[$j] = ", c[j], "(lambda = ",  lambda_[m+j], ")")
+    println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
 end
 println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
 println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))

--- a/examples/nlp2.jl
+++ b/examples/nlp2.jl
@@ -226,7 +226,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 KNITRO.KN_free(kc)
 
 @testset "Exemple HS40 nlp2" begin
-    @test nStatus == 0
-    @test objSol ≈ 0.25
-    @test x ≈ [0.793701, 0.707107, 0.529732, 0.840896] atol=1e-5
+    @test nStatus == KNITRO.KN_RC_USER_TERMINATION
+    @test objSol ≈ 0.25 atol=1e-4
+    @test x ≈ [0.793701, 0.707107, 0.529732, 0.840896] atol=1e-4
 end

--- a/examples/nlp2.jl
+++ b/examples/nlp2.jl
@@ -173,7 +173,6 @@ KNITRO.KN_add_con_quadratic_struct(kc, qconIndexCons, qconIndexVars1, qconIndexV
 #    x0*x1*x2*x3  in the objective
 #    x0^3         in first constraint c0
 #    x0^2*x3      in second constraint c1
-#= cb = KNITRO.KN_add_eval_callback(kc, evalObj = True, indexCons = [0, 1],  callbackEvalFC) =#
 cb = KNITRO.KN_add_eval_callback(kc, true, Int32[0, 1], callbackEvalFC)
 
 # Set obj. gradient and nonlinear jac provided through callbacks.
@@ -193,7 +192,6 @@ KNITRO.KN_set_cb_grad(kc, cb, callbackEvalGA, jacIndexCons=cbjacIndexCons, jacIn
 #(7 nonzero elements)
 cbhessIndexVars1 = Int32[0, 0, 0, 0, 1, 1, 2]
 cbhessIndexVars2 = Int32[0, 1, 2, 3, 2, 3, 3]
-#= KNITRO.KN_set_cb_hess(kc, cb, hessIndexVars1 = cbhessIndexVars1, hessIndexVars2 = cbhessIndexVars2, hessCallback = callbackEvalH) =#
 KNITRO.KN_set_cb_hess(kc, cb, length(cbhessIndexVars1), callbackEvalH,
                       hessIndexVars1=cbhessIndexVars1,  hessIndexVars2=cbhessIndexVars2)
 

--- a/examples/restart.jl
+++ b/examples/restart.jl
@@ -134,7 +134,7 @@ KNITRO.KN_add_con_quadratic_struct(kc, 1, 1, 1, 1.0)
 # via "KNITRO.KN_add_obj_linear_struct()" / "KNITRO.KN_add_obj_quadratic_struct()".
 # However, for simplicity, we evaluate the whole objective
 # function through the callback.
-cb = KNITRO.KN_add_eval_callback(kc, callbackEvalF)
+cb = KNITRO.KN_add_objective_callback(kc, callbackEvalF)
 
 # Also add a callback function "callbackEvalG" to evaluate the
 # objective gradient.  If not provided, Knitro will approximate

--- a/examples/tuner.jl
+++ b/examples/tuner.jl
@@ -130,7 +130,7 @@ KNITRO.KN_add_con_quadratic_struct(kc, 1, 1, 1, 1.0)
 # via "KNITRO.KN_add_obj_linear_struct()" / "KNITRO.KN_add_obj_quadratic_struct()".
 # However, for simplicity, we evaluate the whole objective
 # function through the callback.
-cb = KNITRO.KN_add_eval_callback(kc, callbackEvalF)
+cb = KNITRO.KN_add_objective_callback(kc, callbackEvalF)
 
 # Also add a callback function "callbackEvalG" to evaluate the
 # objective gradient.  If not provided, Knitro will approximate

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -57,14 +57,12 @@ include(joinpath("MOI_wrapper", "utils.jl"))
 
 ##################################################
 mutable struct VariableInfo
-    lower_bound::Float64  # May be -Inf even if has_lower_bound == true
     has_lower_bound::Bool # Implies lower_bound == Inf
-    upper_bound::Float64  # May be Inf even if has_upper_bound == true
     has_upper_bound::Bool # Implies upper_bound == Inf
     is_fixed::Bool        # Implies lower_bound == upper_bound and !has_lower_bound and !has_upper_bound.
     name::String
 end
-VariableInfo() = VariableInfo(-Inf, false, Inf, false, false, "")
+VariableInfo() = VariableInfo(false, false, false, "")
 
 
 ##################################################

--- a/src/MOI_wrapper/constraints.jl
+++ b/src/MOI_wrapper/constraints.jl
@@ -61,7 +61,6 @@ function MOI.add_constraint(model::Optimizer,
         error("Variable $vi is fixed. Cannot also set upper bound.")
     end
     ub = check_value(lt.upper)
-    model.variable_info[vi.value].upper_bound = ub
     model.variable_info[vi.value].has_upper_bound = true
     # By construction, MOI's indexing is the same as KNITRO's indexing.
     KN_set_var_upbnds(model.inner, vi.value - 1, ub)
@@ -83,7 +82,6 @@ function MOI.add_constraint(model::Optimizer,
         error("Variable $vi is fixed. Cannot also set lower bound.")
     end
     lb = check_value(gt.lower)
-    model.variable_info[vi.value].lower_bound = lb
     model.variable_info[vi.value].has_lower_bound = true
     # We assume that MOI's indexing is the same as KNITRO's indexing.
     KN_set_var_lobnds(model.inner, vi.value - 1, lb)
@@ -108,8 +106,6 @@ function MOI.add_constraint(model::Optimizer,
         error("Variable $vi is already fixed.")
     end
     eqv = check_value(eq.value)
-    model.variable_info[vi.value].lower_bound = eqv
-    model.variable_info[vi.value].upper_bound = eqv
     model.variable_info[vi.value].is_fixed = true
     # We assume that MOI's indexing is the same as KNITRO's indexing.
     KN_set_var_fxbnds(model.inner, vi.value - 1, eqv)
@@ -259,17 +255,7 @@ function MOI.add_constraint(model::Optimizer,
     # Made the bounds explicit for KNITRO and take care of
     # preexisting MOI's bounds.
     lobnd = 0.
-    if model.variable_info[indv + 1].has_lower_bound
-        # Knitro automatically set the lowerbound to 0., except
-        # if it is equal to 1.
-        lobnd = model.variable_info[indv +1 ].lower_bound
-    end
     upbnd = 1.
-    if model.variable_info[indv + 1].has_upper_bound
-        # Knitro automatically set the upperbound to 1., except
-        # if it is equal to 0.
-        upbnd = model.variable_info[indv +1 ].upper_bound
-    end
     KN_set_var_lobnds(model.inner, indv, lobnd)
     KN_set_var_upbnds(model.inner, indv, upbnd)
     KN_set_var_type(model.inner, vi.value - 1, KN_VARTYPE_BINARY)

--- a/src/MOI_wrapper/constraints.jl
+++ b/src/MOI_wrapper/constraints.jl
@@ -184,6 +184,10 @@ function MOI.add_constraint(model::Optimizer,
     KN_add_con_linear_struct(model.inner, num_cons, indexvars, coefs)
     # Parse quadratic term.
     qvar1, qvar2, qcoefs = canonical_quadratic_reduction(func)
+    # Take care that Knitro is 0-indexed!
+    qvar1 .= qvar1 .- 1
+    qvar2 .= qvar2 .- 1
+
     KN_add_con_quadratic_struct(model.inner, num_cons, qvar1, qvar2, qcoefs)
     # Add constraints to index.
     ci = MOI.ConstraintIndex{typeof(func), typeof(set)}(num_cons)

--- a/src/MOI_wrapper/objective.jl
+++ b/src/MOI_wrapper/objective.jl
@@ -16,6 +16,9 @@ reset_objective!(model::Optimizer) = (model.objective = nothing)
 function add_objective!(model::Optimizer, objective::MOI.ScalarQuadraticFunction)
     # We parse the expression passed in arguments.
     qobjindex1, qobjindex2, qcoefs = canonical_quadratic_reduction(objective)
+    # Take care that Knitro is 0-indexed!
+    qobjindex1 .-= 1
+    qobjindex2 .-= 1
     lobjindex, lcoefs = canonical_linear_reduction(objective)
     # We load the objective inside KNITRO.
     KN_add_obj_quadratic_struct(model.inner, qobjindex1, qobjindex2, qcoefs)

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -113,7 +113,7 @@ function MOI.get(model::Optimizer,
         error("VariablePrimal not available.")
     end
     check_inbounds(model, vi)
-    return get_solution(model.inner)[vi.value]
+    return get_solution(model.inner, vi.value)
 end
 
 function MOI.get(model::Optimizer,
@@ -159,8 +159,7 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintPrimal,
     end
     vi = MOI.VariableIndex(ci.value)
     check_inbounds(model, vi)
-    x = get_solution(model.inner)
-    return x[vi.value]
+    return get_solution(model.inner, vi.value)
 end
 
 function MOI.get(model::Optimizer, ::MOI.ConstraintPrimal,

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -194,9 +194,6 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
     end
     vi = MOI.VariableIndex(ci.value)
     check_inbounds(model, vi)
-    if !model.variable_info[vi.value].has_upper_bound
-        error("Variable $vi has no upper bound -- ConstraintDual not defined.")
-    end
 
     # Constraints' duals are before reduced costs in KNITRO.
     offset = number_constraints(model)
@@ -215,9 +212,6 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
     end
     vi = MOI.VariableIndex(ci.value)
     check_inbounds(model, vi)
-    if !model.variable_info[vi.value].has_lower_bound
-        error("Variable $vi has no lower bound -- ConstraintDual not defined.")
-    end
 
     # Constraints' duals are before reduced costs in KNITRO.
     offset = number_constraints(model)
@@ -236,9 +230,6 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
     end
     vi = MOI.VariableIndex(ci.value)
     check_inbounds(model, vi)
-    if !model.variable_info[vi.value].is_fixed
-        error("Variable $vi is not fixed -- ConstraintDual not defined.")
-    end
 
     # Constraints' duals are before reduced costs in KNITRO.
     offset = number_constraints(model)

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -260,3 +260,10 @@ function MOI.get(model::Optimizer, ::MOI.NLPBlockDual)
     # and quadratic constraint, but this is not tested inside MOI.
     return sense_dual(model) .* [lambda[i+1] for i in model.nlp_index_cons]
 end
+
+###
+# Additional getters
+MOI.get(model::Optimizer, ::MOI.NodeCount) = KN_get_mip_number_nodes(model)
+MOI.get(model::Optimizer, ::MOI.BarrierIterations) = KN_get_number_iters(model)
+MOI.get(model::Optimizer, ::MOI.RelativeGap) = KN_get_mip_rel_gap(model)
+MOI.get(model::Optimizer, ::MOI.ObjectiveBound) = KN_get_mip_relaxation_bnd(model)

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -198,15 +198,13 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
         error("Variable $vi has no upper bound -- ConstraintDual not defined.")
     end
 
-    xsol = get_solution(model.inner)
-    # TODO: is fixing a tolerance the best solution?
-    if isapprox(xsol[vi.value], model.variable_info[vi.value].upper_bound, atol=1e-4)
-        # Constraints' duals are before reduced costs in KNITRO.
-        offset = number_constraints(model)
-        lambda = get_dual(model.inner)
-        return sense_dual(model) * lambda[vi.value + offset]
+    # Constraints' duals are before reduced costs in KNITRO.
+    offset = number_constraints(model)
+    lambda = sense_dual(model) * get_dual(model.inner, vi.value + offset)
+    if lambda < 0
+        return lambda
     else
-        return 0.
+        return 0
     end
 end
 
@@ -221,15 +219,13 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
         error("Variable $vi has no lower bound -- ConstraintDual not defined.")
     end
 
-    xsol = get_solution(model.inner)
-    # TODO: is fixing a tolerance the best solution?
-    if isapprox(xsol[vi.value], model.variable_info[vi.value].lower_bound, atol=1e-4)
-        # Constraints' duals are before reduced costs in KNITRO.
-        offset = number_constraints(model)
-        lambda = get_dual(model.inner)
-        return sense_dual(model) * lambda[vi.value + offset]
+    # Constraints' duals are before reduced costs in KNITRO.
+    offset = number_constraints(model)
+    lambda = sense_dual(model) * get_dual(model.inner, vi.value + offset)
+    if lambda > 0
+        return lambda
     else
-        return 0.
+        return 0
     end
 end
 
@@ -246,8 +242,8 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintDual,
 
     # Constraints' duals are before reduced costs in KNITRO.
     offset = number_constraints(model)
-    lambda = get_dual(model.inner)
-    return sense_dual(model) * lambda[vi.value + offset]
+    lambda = get_dual(model.inner, vi.value + offset)
+    return sense_dual(model) * lambda
 end
 
 function MOI.get(model::Optimizer, ::MOI.NLPBlockDual)

--- a/src/MOI_wrapper/utils.jl
+++ b/src/MOI_wrapper/utils.jl
@@ -16,20 +16,18 @@ Warning: we assume in this function that all variables are correctly
 ordered, that is no deletion or swap has occured.
 """
 function canonical_quadratic_reduction(func::MOI.ScalarQuadraticFunction)
+    # Take care that Julia is 1-indexed.
     quad_columns_1, quad_columns_2, quad_coefficients = (
-        Int32[term.variable_index_1.value for term in func.quadratic_terms],
-        Int32[term.variable_index_2.value for term in func.quadratic_terms],
+        Int32[term.variable_index_1.value - 1 for term in func.quadratic_terms],
+        Int32[term.variable_index_2.value - 1 for term in func.quadratic_terms],
         [term.coefficient for term in func.quadratic_terms]
     )
     # Take care of difference between MOI standards and KNITRO ones.
     for i in 1:length(quad_coefficients)
-        if quad_columns_1[i] == quad_columns_2[i]
+        @inbounds if quad_columns_1[i] == quad_columns_2[i]
             quad_coefficients[i] *= .5
         end
     end
-    # Take care that Julia is 1-indexed.
-    quad_columns_1 .-= 1
-    quad_columns_2 .-= 1
     return quad_columns_1, quad_columns_2, quad_coefficients
 end
 
@@ -45,15 +43,13 @@ Warning: we assume in this function that all variables are correctly
 ordered, that is no deletion or swap has occured.
 """
 function canonical_linear_reduction(func::MOI.ScalarQuadraticFunction)
-    affine_columns = Int32[term.variable_index.value for term in func.affine_terms]
+    affine_columns = Int32[term.variable_index.value - 1 for term in func.affine_terms]
     affine_coefficients = [term.coefficient for term in func.affine_terms]
-    affine_columns .-= 1
     return affine_columns, affine_coefficients
 end
 function canonical_linear_reduction(func::MOI.ScalarAffineFunction)
-    affine_columns = Int32[term.variable_index.value for term in func.terms]
+    affine_columns = Int32[term.variable_index.value - 1 for term in func.terms]
     affine_coefficients = [term.coefficient for term in func.terms]
-    affine_columns .-= 1
     return affine_columns, affine_coefficients
 end
 
@@ -63,12 +59,10 @@ function canonical_vector_affine_reduction(func::MOI.VectorAffineFunction)
     coefs = Float64[]
 
     for t in func.terms
-        push!(index_cols, t.output_index)
-        push!(index_vars, t.scalar_term.variable_index.value)
+        push!(index_cols, t.output_index - 1)
+        push!(index_vars, t.scalar_term.variable_index.value - 1)
         push!(coefs, t.scalar_term.coefficient)
     end
-    index_cols .-= 1
-    index_vars .-= 1
     return index_cols, index_vars, coefs
 end
 

--- a/src/MOI_wrapper/variables.jl
+++ b/src/MOI_wrapper/variables.jl
@@ -16,7 +16,9 @@ function MOI.add_variable(model::Optimizer)
     (model.number_solved >= 1) && throw(AddVariableError())
     push!(model.variable_info, VariableInfo())
     KN_add_var(model.inner)
-    return MOI.VariableIndex(length(model.variable_info))
+    nvars = length(model.variable_info)
+    KN_set_var_primal_init_values(model.inner, nvars - 1, 0.)
+    return MOI.VariableIndex(nvars)
 end
 function MOI.add_variables(model::Optimizer, n::Int)
     return [MOI.add_variable(model) for i in 1:n]
@@ -79,7 +81,7 @@ function MOI.set(model::Optimizer, ::MOI.VariablePrimalStart,
         KN_set_var_primal_init_values(model.inner, vi.value - 1, Cdouble(value))
     else
         # By default, initial value is set to 0.
-        KN_set_var_primal_init_values(model.inner, vi.value - 1, Cdouble(0.))
+        KN_set_var_primal_init_values(model.inner, vi.value - 1, 0.)
     end
     return
 end

--- a/src/MOI_wrapper/variables.jl
+++ b/src/MOI_wrapper/variables.jl
@@ -17,6 +17,7 @@ function MOI.add_variable(model::Optimizer)
     push!(model.variable_info, VariableInfo())
     KN_add_var(model.inner)
     nvars = length(model.variable_info)
+    # By default, initial value is set to 0.
     KN_set_var_primal_init_values(model.inner, nvars - 1, 0.)
     return MOI.VariableIndex(nvars)
 end

--- a/src/kn_attributes.jl
+++ b/src/kn_attributes.jl
@@ -347,20 +347,23 @@ function KN_get_hessian_values(m::Model)
     return indexVars1, indexVars2, hess
 end
 
-function KN_get_solve_time_cpu(m::Model)
-    tcpu = zeros(Cdouble, 1)
-    ret = @kn_ccall(get_solve_time_cpu, Cint,
-                    (Ptr{Cvoid}, Ptr{Cdouble}), m.env, tcpu)
-    _checkraise(ret)
-    return tcpu[1]
-end
+# Getters for CPU time are implemented only for Knitro version >= 12.0.
+if KNITRO_VERSION >= v"12.0"
+    function KN_get_solve_time_cpu(m::Model)
+        tcpu = zeros(Cdouble, 1)
+        ret = @kn_ccall(get_solve_time_cpu, Cint,
+                        (Ptr{Cvoid}, Ptr{Cdouble}), m.env, tcpu)
+        _checkraise(ret)
+        return tcpu[1]
+    end
 
-function KN_get_solve_time_real(m::Model)
-    treal = zeros(Cdouble, 1)
-    ret = @kn_ccall(get_solve_time_real, Cint,
-                    (Ptr{Cvoid}, Ptr{Cdouble}), m.env, treal)
-    _checkraise(ret)
-    return treal[1]
+    function KN_get_solve_time_real(m::Model)
+        treal = zeros(Cdouble, 1)
+        ret = @kn_ccall(get_solve_time_real, Cint,
+                        (Ptr{Cvoid}, Ptr{Cdouble}), m.env, treal)
+        _checkraise(ret)
+        return treal[1]
+    end
 end
 ##################################################
 # MIP utils

--- a/src/kn_attributes.jl
+++ b/src/kn_attributes.jl
@@ -347,7 +347,21 @@ function KN_get_hessian_values(m::Model)
     return indexVars1, indexVars2, hess
 end
 
+function KN_get_solve_time_cpu(m::Model)
+    tcpu = zeros(Cdouble, 1)
+    ret = @kn_ccall(get_solve_time_cpu, Cint,
+                    (Ptr{Cvoid}, Ptr{Cdouble}), m.env, tcpu)
+    _checkraise(ret)
+    return tcpu[1]
+end
 
+function KN_get_solve_time_real(m::Model)
+    treal = zeros(Cdouble, 1)
+    ret = @kn_ccall(get_solve_time_real, Cint,
+                    (Ptr{Cvoid}, Ptr{Cdouble}), m.env, treal)
+    _checkraise(ret)
+    return treal[1]
+end
 ##################################################
 # MIP utils
 ##################################################

--- a/src/kn_callbacks.jl
+++ b/src/kn_callbacks.jl
@@ -119,7 +119,7 @@ function KN_get_cb_objgrad_nnz(m::Model, cb::Ptr{Cvoid})
 end
 
 function KN_get_cb_jacobian_nnz(m::Model, cb::Ptr{Cvoid})
-    num = Cint[0]
+    num = KNLONG[0]
     ret = @kn_ccall(get_cb_jacobian_nnz,
                     Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                     m.env, cb, num)
@@ -128,7 +128,7 @@ function KN_get_cb_jacobian_nnz(m::Model, cb::Ptr{Cvoid})
 end
 
 function KN_get_cb_hessian_nnz(m::Model, cb::Ptr{Cvoid})
-    num = Cint[0]
+    num = KNLONG[0]
     ret = @kn_ccall(get_cb_hessian_nnz,
                     Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                     m.env, cb, num)
@@ -146,7 +146,7 @@ function KN_get_cb_number_rsds(m::Model, cb::Ptr{Cvoid})
 end
 
 function KN_get_cb_rsd_jacobian_nnz(m::Model, cb::Ptr{Cvoid})
-    num = Cint[0]
+    num = KNLONG[0]
     ret = @kn_ccall(get_cb_rsd_jacobian_nnz,
                     Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}),
                     m.env, cb, num)

--- a/src/kn_model.jl
+++ b/src/kn_model.jl
@@ -1,15 +1,22 @@
-# Knitro model
+# Knitro model.
 
 
 ##################################################
-# Model definition
+# Model definition.
 ##################################################
 mutable struct Model
-    # KNITRO context environment
+    # KNITRO context environment.
     env::Env
     userdata::Dict
 
-    # special callbacks (undefined by default)
+    # Solution values.
+    # Optimization status. Equal to 1 if problem is unsolved.
+    status::Cint
+    obj_val::Cdouble
+    x::Vector{Cdouble}
+    mult::Vector{Cdouble}
+
+    # Special callbacks (undefined by default).
     # (this functions do not depend on callback environments)
     ms_process::Function
     mip_callback::Function
@@ -17,14 +24,14 @@ mutable struct Model
     ms_initpt_callback::Function
     puts_callback::Function
 
-    # constructor
+    # Constructor.
     function Model()
-        model = new(Env(), Dict())
-        # add a destructor to properly delete model
+        model = new(Env(), Dict(), 1, Inf, Cdouble[], Cdouble[])
+        # Add a destructor to properly delete model.
         finalizer(KN_free, model)
         return model
     end
-    # create Model with license manager
+    # Create Model with license manager.
     function Model(lm::LMcontext)
         model = new(Env(lm), Dict())
         finalizer(KN_free, model)
@@ -42,26 +49,25 @@ KN_new_lm(lm::LMcontext) = Model(lm)
 is_valid(m::Model) = is_valid(m.env)
 
 
-
 ##################################################
 # Basic model manipulation
 ##################################################
 
-"Set all parameters specified in the given file"
+"Set all parameters specified in the given file."
 function KN_load_param_file(m::Model, filename::AbstractString)
     ret = @kn_ccall(load_param_file, Cint, (Ptr{Cvoid}, Ptr{Cchar}),
                     m.env, filename)
     _checkraise(ret)
 end
 
-"Save current parameters in the given file"
+"Save current parameters in the given file."
 function KN_save_param_file(m::Model, filename::AbstractString)
     ret = @kn_ccall(save_param_file, Cint, (Ptr{Cvoid}, Ptr{Cchar}),
                     m.env, filename)
     _checkraise(ret)
 end
 
-"Reset all parameters to default values"
+"Reset all parameters to default values."
 function KN_reset_params_to_defaults(m::Model)
     ret = @kn_ccall(reset_params_to_defaults, Cint, (Ptr{Cvoid}, ),
                     m.env)
@@ -75,6 +81,7 @@ function KN_load_tuner_file(m::Model, filename::AbstractString)
     _checkraise(ret)
 end
 
+"Load MPS file."
 function KN_load_mps_file(m::Model, filename::AbstractString)
     @assert KNITRO_VERSION >= v"12.0"
     ret = @kn_ccall(load_mps_file, Cint, (Ptr{Cvoid}, Ptr{Cchar}),

--- a/test/knitroapi.jl
+++ b/test/knitroapi.jl
@@ -540,7 +540,7 @@ end
     KNITRO.KN_add_con_quadratic_struct(kc, 0, 1, 2, 1.0)
 
     # Define callback functions.
-    cb = KNITRO.KN_add_eval_callback(kc, evalAll)
+    cb = KNITRO.KN_add_eval_callback_all(kc, evalAll)
     KNITRO.KN_set_cb_grad(kc, cb, evalAll)
     KNITRO.KN_set_cb_hess(kc, cb, KNITRO.KN_DENSE_ROWMAJOR, evalAll)
 

--- a/test/knitroapi.jl
+++ b/test/knitroapi.jl
@@ -172,7 +172,7 @@ println()
     KNITRO.KN_add_con_quadratic_struct(kc, 0, 1, 2, 1.0)
 
     # Define callback functions.
-    cb = KNITRO.KN_add_eval_callback(kc, evalAll)
+    cb = KNITRO.KN_add_objective_callback(kc, evalAll)
     KNITRO.KN_set_cb_grad(kc, cb, evalAll)
     KNITRO.KN_set_cb_hess(kc, cb, 5, evalAll,
                           hessIndexVars1=Int32[0, 0, 1, 1, 2],
@@ -275,7 +275,7 @@ println()
     KNITRO.KN_add_con_quadratic_struct(kc, 0, 1, 2, 1.0)
 
     # Define callback functions.
-    cb = KNITRO.KN_add_eval_callback(kc, evalAll)
+    cb = KNITRO.KN_add_objective_callback(kc, evalAll)
 
     KNITRO.KN_set_cb_grad(kc, cb, evalAll)
     KNITRO.KN_set_cb_hess(kc, cb, KNITRO.KN_DENSE_ROWMAJOR, evalAll)
@@ -344,7 +344,7 @@ println()
     KNITRO.KN_add_con_quadratic_struct(kc, 0, 1, 2, 1.0)
 
     # Define callback functions.
-    cb = KNITRO.KN_add_eval_callback(kc, evalAll)
+    cb = KNITRO.KN_add_objective_callback(kc, evalAll)
     KNITRO.KN_set_cb_grad(kc, cb, evalAll)
     KNITRO.KN_set_cb_hess(kc, cb, KNITRO.KN_DENSE_ROWMAJOR, evalAll)
 
@@ -432,7 +432,7 @@ println()
     KNITRO.KN_add_con_quadratic_struct(kc, 0, 1, 2, 1.0)
 
     # Define callback functions.
-    cb = KNITRO.KN_add_eval_callback(kc, evalF_evalGA)
+    cb = KNITRO.KN_add_objective_callback(kc, evalF_evalGA)
     KNITRO.KN_set_cb_grad(kc, cb, evalF_evalGA)
 
     # Define complementarity constraints


### PR DESCRIPTION
- Cache Knitro's optimization results in `KNITRO.Model` to improve efficiency of MOI getters 
- Implement more MOI getters 
- Fix once and for all the order of constraints when building NLP model with MOI: 
    * Previous order was implicit, and defined when calling the function [optimize!](https://github.com/JuliaOpt/JuMP.jl/blob/master/src/optimizer_interface.jl#L105-#L108) in JuMP. By doing so, NLP constraints were set at the begining: `[nlp_constraints; other_constraints]`
    * NLP constraints are now always defined at the end of the Knitro's model (`[other_constraints; nlp_constraints]`). By doing so, we avoid side effect in JuMP and ease the future integration of JuMP's direct mode in KNITRO.jl. 
- Avoid storing unecessary information in `KNITRO.Optimizer` (e.g. variables' upper and lower bounds)


Note that the order of constraints impacts Knitro's performance when solving large-scale instances (for instance those of [PowerModels.jl](https://github.com/lanl-ansi/PowerModels.jl)). This PR could lead to difference in Knitro's convergence. 