### PR TITLE
do not require Compat to build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,4 @@
-using Compat
-using Compat.Libdl
+using Libdl
 
 depsfile = joinpath(dirname(@__FILE__), "deps.jl")
 
@@ -20,7 +19,7 @@ end
 
 paths_to_try = String[]
 
-libname = string(Compat.Sys.iswindows() ? "" : "lib", "knitro", ".", Libdl.dlext)
+libname = string(Base.Sys.iswindows() ? "" : "lib", "knitro", ".", Libdl.dlext)
 
 # try to load absolute path before
 if haskey(ENV, "KNITRODIR")


### PR DESCRIPTION
With Julia ≥ 1, we don't really need Compat to build. And in fact, I wasn't able to build KNITRO under Julia 1.2.0-rc3 without this change.
