### PR TITLE
Clean wrapping of Knitro callbacks in Julia

### DIFF
--- a/examples/multipleCB.jl
+++ b/examples/multipleCB.jl
@@ -30,7 +30,7 @@ using KNITRO, Test
 # The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
 # Only "obj" is set in the KNITRO.KN_eval_result structure.
 function callbackEvalObj(kc, cb, evalRequest, evalResult, userParams)
-    xind = userParams[:data]
+    xind = userParams
 
     if evalRequest.evalRequestCode != KNITRO.KN_RC_EVALFC
         println("*** callbackEvalObj incorrectly called with eval type ", evalRequest.evalRequestCode)
@@ -47,7 +47,7 @@ end
 # The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
 # Only "c0" is set in the KNITRO.KN_eval_result structure.
 function callbackEvalC0(kc, cb, evalRequest, evalResult, userParams)
-    xind = userParams[:data]
+    xind = userParams
 
     if evalRequest.evalRequestCode != KNITRO.KN_RC_EVALFC
         println("*** callbackEvalC0 incorrectly called with eval type ", evalRequest.evalRequestCode)
@@ -64,7 +64,7 @@ end
 # The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
 # Only "c1" is set in the KNITRO.KN_eval_result structure.
 function callbackEvalC1(kc, cb, evalRequest, evalResult, userParams)
-    xind = userParams[:data]
+    xind = userParams
 
     if evalRequest.evalRequestCode != KNITRO.KN_RC_EVALFC
         println("*** callbackEvalC1 incorrectly called with eval type %d" % evalRequest.evalRequestCode)
@@ -85,7 +85,7 @@ end
 # The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
 # Only "objGrad" is set in the KNITRO.KN_eval_result structure.
 function callbackEvalObjGrad(kc, cb, evalRequest, evalResult, userParams)
-    xind = userParams[:data]
+    xind = userParams
 
     if evalRequest.evalRequestCode != KNITRO.KN_RC_EVALGA
         println("*** callbackEvalObjGrad incorrectly called with eval type %d" % evalRequest.evalRequestCode)
@@ -105,7 +105,7 @@ end
 # The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
 # Only gradient of c0 is set in the KNITRO.KN_eval_result structure.
 function callbackEvalC0Grad(kc, cb, evalRequest, evalResult, userParams)
-    xind = userParams[:data]
+    xind = userParams
 
     if evalRequest.evalRequestCode != KNITRO.KN_RC_EVALGA
         println("*** callbackEvalC0Grad incorrectly called with eval type ", evalRequest.evalRequestCode)

--- a/src/KNITRO.jl
+++ b/src/KNITRO.jl
@@ -17,7 +17,7 @@ module KNITRO
         f = Base.Meta.quot(Symbol("KTR_$(func)"))
         args = [esc(a) for a in args]
         quote
-            ccall(($f,libknitro), $(args...))
+            ccall(($f, libknitro), $(args...))
         end
     end
     "Load KNITRO version number via KTR API."

--- a/src/kn_attributes.jl
+++ b/src/kn_attributes.jl
@@ -103,21 +103,23 @@ end
 ##################################################
 # Generic getters
 ##################################################
-function KN_get_number_vars(m::Model)
+function KN_get_number_vars(kc::Ptr{Cvoid})
     num_vars = Cint[0]
     ret = @kn_ccall(get_number_vars, Cint, (Ptr{Cvoid}, Ptr{Cint}),
-                    m.env, num_vars)
+                    kc, num_vars)
     _checkraise(ret)
     return num_vars[1]
 end
+KN_get_number_vars(model::Model) = KN_get_number_vars(model.env.ptr_env)
 
-function KN_get_number_cons(m::Model)
+function KN_get_number_cons(kc::Ptr{Cvoid})
     num_cons = Cint[0]
     ret = @kn_ccall(get_number_cons, Cint, (Ptr{Cvoid}, Ptr{Cint}),
-                    m.env, num_cons)
+                    kc, num_cons)
     _checkraise(ret)
     return num_cons[1]
 end
+KN_get_number_cons(model::Model) = KN_get_number_cons(model.env.ptr_env)
 
 function KN_get_obj_value(m::Model)
     obj = Cdouble[0]

--- a/src/kn_callbacks.jl
+++ b/src/kn_callbacks.jl
@@ -5,7 +5,7 @@
 ##################################################
 function KN_set_cb_user_params(m::Model, cb::CallbackContext, userParams=nothing)
     if userParams != nothing
-        cb.userparams[:data] = userParams
+        cb.userparams = userParams
     end
     # Store callback context inside KNITRO user data.
     c_userdata = cb
@@ -227,11 +227,11 @@ macro wrap_function(wrap_name, name)
                                    userdata_::Ptr{Cvoid})
             try
                 # Load evalRequest object.
-                ptr0 = Ptr{KN_eval_request}(evalRequest_)
-                evalRequest = unsafe_load(ptr0)::KN_eval_request
+                ptr_request = Ptr{KN_eval_request}(evalRequest_)
+                evalRequest = unsafe_load(ptr_request)::KN_eval_request
                 # Load evalResult object.
-                ptr = Ptr{KN_eval_result}(evalResults_)
-                evalResult = unsafe_load(ptr)::KN_eval_result
+                ptr_result = Ptr{KN_eval_result}(evalResults_)
+                evalResult = unsafe_load(ptr_result)::KN_eval_result
                 # Eventually, load callback context.
                 cb = unsafe_pointer_to_objref(userdata_)
                 # Ensure that cb is a CallbackContext.

--- a/src/kn_callbacks.jl
+++ b/src/kn_callbacks.jl
@@ -600,17 +600,22 @@ function newpt_wrapper(ptr_model::Ptr{Cvoid},
                        ptr_x::Ptr{Cdouble},
                        ptr_lambda::Ptr{Cdouble},
                        userdata_::Ptr{Cvoid})
-
     # Load KNITRO's Julia Model.
-    m = unsafe_pointer_to_objref(userdata_)::Model
-    nx = KN_get_number_vars(m)
-    nc = KN_get_number_cons(m)
-
-    x = unsafe_wrap(Array, ptr_x, nx)
-    lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
-    ret = m.user_callback(ptr_model, x, lambda, m)
-
-    return Cint(ret)
+    try
+        m = unsafe_pointer_to_objref(userdata_)::Model
+        nx = KN_get_number_vars(m)
+        nc = KN_get_number_cons(m)
+        x = unsafe_wrap(Array, ptr_x, nx)
+        lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
+        ret = m.user_callback(ptr_model, x, lambda, m)
+        return Cint(ret)
+    catch ex
+        if isa(ex, InterruptException)
+            return Cint(KN_RC_USER_TERMINATION)
+        else
+            rethrow(ex)
+        end
+    end
 end
 
 """
@@ -660,15 +665,21 @@ function ms_process_wrapper(ptr_model::Ptr{Cvoid},
                             userdata_::Ptr{Cvoid})
 
     # Load KNITRO's Julia Model.
-    m = unsafe_pointer_to_objref(userdata_)::Model
-    nx = KN_get_number_vars(m)
-    nc = KN_get_number_cons(m)
-
-    x = unsafe_wrap(Array, ptr_x, nx)
-    lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
-    res = m.ms_process(ptr_model, x, lambda, m)
-
-    return Cint(res)
+    try
+        m = unsafe_pointer_to_objref(userdata_)::Model
+        nx = KN_get_number_vars(m)
+        nc = KN_get_number_cons(m)
+        x = unsafe_wrap(Array, ptr_x, nx)
+        lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
+        res = m.ms_process(ptr_model, x, lambda, m)
+        return Cint(res)
+    catch ex
+        if isa(ex, InterruptException)
+            return Cint(KN_RC_USER_TERMINATION)
+        else
+            rethrow(ex)
+        end
+    end
 end
 
 """
@@ -712,15 +723,21 @@ function mip_node_callback_wrapper(ptr_model::Ptr{Cvoid},
                                    ptr_lambda::Ptr{Cdouble},
                                    userdata_::Ptr{Cvoid})
     # Load KNITRO's Julia Model.
-    m = unsafe_pointer_to_objref(userdata_)::Model
-    nx = KN_get_number_vars(m)
-    nc = KN_get_number_cons(m)
-
-    x = unsafe_wrap(Array, ptr_x, nx)
-    lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
-    res = m.mip_callback(ptr_model, x, lambda, m)
-
-    return Cint(res)
+    try
+        m = unsafe_pointer_to_objref(userdata_)::Model
+        nx = KN_get_number_vars(m)
+        nc = KN_get_number_cons(m)
+        x = unsafe_wrap(Array, ptr_x, nx)
+        lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
+        res = m.mip_callback(ptr_model, x, lambda, m)
+        return Cint(res)
+    catch ex
+        if isa(ex, InterruptException)
+            return Cint(KN_RC_USER_TERMINATION)
+        else
+            rethrow(ex)
+        end
+    end
 end
 
 """
@@ -814,10 +831,17 @@ end
 function puts_callback_wrapper(str::Ptr{Cchar}, userdata_::Ptr{Cvoid})
 
     # Load KNITRO's Julia Model.
-    m = unsafe_pointer_to_objref(userdata_)::Model
-    res = m.puts_callback(unsafe_string(str), m.userdata)
-
-    return Cint(res)
+    try
+        m = unsafe_pointer_to_objref(userdata_)::Model
+        res = m.puts_callback(unsafe_string(str), m.userdata)
+        return Cint(res)
+    catch ex
+        if isa(ex, InterruptException)
+            return Cint(KN_RC_USER_TERMINATION)
+        else
+            rethrow(ex)
+        end
+    end
 end
 
 """

--- a/src/kn_model.jl
+++ b/src/kn_model.jl
@@ -1,5 +1,10 @@
 # Knitro model.
 
+struct UserParams{T}
+    params::T
+end
+UserParams() = UserParams(nothing)
+
 """
 Structure specifying the callback context.
 
@@ -10,7 +15,7 @@ is attached to a unique callback context.
 mutable struct CallbackContext
     context::Ptr{Cvoid}
     # Add a dictionnary to store user params.
-    userparams::Dict
+    userparams::UserParams
 
     # Oracle's callbacks are context dependent, so store
     # them inside dedicated CallbackContext.
@@ -20,8 +25,8 @@ mutable struct CallbackContext
     eval_rsd::Function
     eval_jac_rsd::Function
 
-    function CallbackContext(ptr::Ptr{Cvoid})
-        return new(ptr, Dict())
+    function CallbackContext(ptr_cb::Ptr{Cvoid})
+        return new(ptr_cb, UserParams())
     end
 end
 

--- a/src/kn_model.jl
+++ b/src/kn_model.jl
@@ -10,6 +10,8 @@ is attached to a unique callback context.
 """
 mutable struct CallbackContext
     context::Ptr{Cvoid}
+    n::Int
+    m::Int
     # Add a dictionnary to store user params.
     userparams
 
@@ -22,7 +24,7 @@ mutable struct CallbackContext
     eval_jac_rsd::Function
 
     function CallbackContext(ptr_cb::Ptr{Cvoid})
-        return new(ptr_cb, nothing)
+        return new(ptr_cb, 0, 0, nothing)
     end
 end
 

--- a/src/kn_model.jl
+++ b/src/kn_model.jl
@@ -1,9 +1,5 @@
 # Knitro model.
 
-struct UserParams{T}
-    params::T
-end
-UserParams() = UserParams(nothing)
 
 """
 Structure specifying the callback context.
@@ -15,7 +11,7 @@ is attached to a unique callback context.
 mutable struct CallbackContext
     context::Ptr{Cvoid}
     # Add a dictionnary to store user params.
-    userparams::UserParams
+    userparams
 
     # Oracle's callbacks are context dependent, so store
     # them inside dedicated CallbackContext.
@@ -26,7 +22,7 @@ mutable struct CallbackContext
     eval_jac_rsd::Function
 
     function CallbackContext(ptr_cb::Ptr{Cvoid})
-        return new(ptr_cb, UserParams())
+        return new(ptr_cb, nothing)
     end
 end
 

--- a/src/kn_variables.jl
+++ b/src/kn_variables.jl
@@ -269,7 +269,12 @@ function KN_set_var_primal_init_values(m::Model, xinitval::Vector{Cdouble})
                     m.env, xinitval)
     _checkraise(ret)
 end
-
+function KN_set_var_primal_init_values(m::Model, xindex::Vector{Cint}, xinitval::Vector{Cdouble})
+    ret = @kn_ccall(set_var_primal_init_values, Cint,
+                    (Ptr{Cvoid}, Cint, Ptr{Cint}, Ptr{Cdouble}),
+                    m.env, length(xindex), xindex, xinitval)
+    _checkraise(ret)
+end
 function KN_set_var_primal_init_values(m::Model, indx::Integer, xinitval::Cdouble)
     ret = @kn_ccall(set_var_primal_init_value, Cint,
                     (Ptr{Cvoid}, Cint, Cdouble), m.env, indx, xinitval)
@@ -283,7 +288,12 @@ function KN_set_var_dual_init_values(m::Model, xinitval::Vector{Cdouble})
                     m.env, xinitval)
     _checkraise(ret)
 end
-
+function KN_set_var_dual_init_values(m::Model, cindex::Vector{Cint}, initval::Vector{Cdouble})
+    ret = @kn_ccall(set_var_dual_init_values, Cint,
+                    (Ptr{Cvoid}, Ptr{Cint}, Ptr{Cdouble}),
+                    m.env, cindex, initval)
+    _checkraise(ret)
+end
 function KN_set_var_dual_init_values(m::Model, indx::Integer, xinitval::Cdouble)
     ret = @kn_ccall(set_var_dual_init_value, Cint,
                     (Ptr{Cvoid}, Cint, Cdouble), m.env, indx, xinitval)

--- a/test/knitroapi.jl
+++ b/test/knitroapi.jl
@@ -495,6 +495,8 @@ end
 
 
 @testset "Fifth problem test" begin
+    # Test in this environment the setting of user params
+    myParams = "stringUserParam"
     kc = KNITRO.KN_new()
 
     # START: Some specific parameter settings
@@ -504,6 +506,9 @@ end
 
     function evalR(kc, cb, evalRequest, evalResult, userParams)
         x = evalRequest.x
+        # Each time we call this callback, the userParams should
+        # be as specified.
+        @test userParams == myParams
         evalResult.rsd[1] = x[1] * 1.309^x[2] - 2.138
         evalResult.rsd[2] = x[1] * 1.471^x[2] - 3.421
         evalResult.rsd[3] = x[1] * 1.49^x[2] - 3.597
@@ -515,6 +520,9 @@ end
 
     function evalJ(kc, cb, evalRequest, evalResult, userParams)
         x = evalRequest.x
+        # Each time we call this callback, the userParams should
+        # be as specified.
+        @test userParams == myParams
         evalResult.rsdJac[1] = 1.309^x[2]
         evalResult.rsdJac[2] = x[1] * log(1.309) * 1.309^x[2]
         evalResult.rsdJac[3] = 1.471^x[2]
@@ -546,6 +554,7 @@ end
     KNITRO.KN_set_cb_rsd_jac(kc, cb, nnzJ, evalJ,
                             jacIndexRsds=Int32[ 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5 ],
                             jacIndexVars=Int32[ 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 ])
+    KNITRO.KN_set_cb_user_params(kc, cb, myParams)
 
     # Solve the problem.
     status = KNITRO.KN_solve(kc)


### PR DESCRIPTION
This PR cleans the wrapping of Knitro callbacks. The wrappers are now using directly the information form the C objects rather than querying it from the Julia object `KNITRO.Model`. 
Furthermore:
- we fix a bug in branch&bound, when using MINLPTests (in this case, Knitro copies the original model and adds new variables and constraints to handle new cuts)
- we now handle user interruption (`CTRL+C`) for all callbacks, not just evaluation callbacks
- we add missing methods to add primal and dual initial starts

**Important notice:** This PR adds a breaking change in the way user data are handled inside the callbacks. To fetch the user data, the user now has to write in the callbacks:
```julia
function eval_function(kc, cb, evalRequest, evalResult, userParams)
    my_data = userParams
    ...
end
```
instead of: 
```julia
function eval_function(kc, cb, evalRequest, evalResult, userParams)
    my_data = userParams[:data]
    ...
end
```

**Second important notice:** This PR does not allow to resolve #93 