### PR TITLE
Better handling of userparams in Knitro callbacks

### DIFF
--- a/examples/minlp1.jl
+++ b/examples/minlp1.jl
@@ -111,9 +111,8 @@ end
 # Argument "kcSub" is the context pointer for the last node
 # subproblem solved inside Knitro.  The application level context
 # pointer is passed in through "userParams".
-function callbackProcessNode(kcSub, x, lambda_, userParams)
+function callbackProcessNode(kc, x, lambda_, userParams)
     # The Knitro context pointer was passed in through "userParams".
-    kc = userParams
 
     # Print info about the status of the MIP solution.
     numNodes = KNITRO.KN_get_mip_number_nodes(kc)

--- a/examples/multistart.jl
+++ b/examples/multistart.jl
@@ -93,9 +93,9 @@ end
 function  callbackMSProcess(kcSub, x, lambda_, userParams)
     # Print solution of the just completed multi-start solve.
 
-    n = KNITRO.KN_get_number_vars(userParams)
+    n = KNITRO.KN_get_number_vars(kc)
     println("callbackMSProcess: ")
-    println("    Last solution: obj= ", KNITRO.KN_get_obj_value(userParams))
+    println("    Last solution: obj= ", KNITRO.KN_get_obj_value(kc))
     for i in 1:n
         println("                   x[$i]= ", x[i])
     end

--- a/examples/nlp2.jl
+++ b/examples/nlp2.jl
@@ -111,18 +111,18 @@ end
 function callbackNewPoint(kc, x, lambda_, userParams)
 
     # Get the number of variables in the model
-    n = KNITRO.KN_get_number_vars(userParams)
+    n = KNITRO.KN_get_number_vars(kc)
 
     println(">> New point computed by Knitro:(", x, ")")
 
     # Query information about the current problem.
-    dFeasError = KNITRO.KN_get_abs_feas_error(userParams)
-    println("Number FC evals= ", KNITRO.KN_get_number_FC_evals(userParams))
+    dFeasError = KNITRO.KN_get_abs_feas_error(kc)
+    println("Number FC evals= ", KNITRO.KN_get_number_FC_evals(kc))
     println("Current feasError= " , dFeasError)
 
     # Demonstrate user-defined termination
     #(Uncomment to activate)
-    if KNITRO.KN_get_obj_value(userParams) > 0.2 && dFeasError <= 1.0e-4
+    if KNITRO.KN_get_obj_value(kc) > 0.2 && dFeasError <= 1.0e-4
         return KNITRO.KN_RC_USER_TERMINATION
     end
 

--- a/src/kn_callbacks.jl
+++ b/src/kn_callbacks.jl
@@ -617,7 +617,7 @@ function newpt_wrapper(ptr_model::Ptr{Cvoid},
         nc = KN_get_number_cons(m)
         x = unsafe_wrap(Array, ptr_x, nx)
         lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
-        ret = m.user_callback(ptr_model, x, lambda, m)
+        ret = m.newpt_callback(m, x, lambda, m.newpoint_user)
         return Cint(ret)
     catch ex
         if isa(ex, InterruptException)
@@ -650,9 +650,12 @@ queried using the corresonding KN_get_XXX_values methods.
 Note: Currently only active for continuous models.
 
 """
-function KN_set_newpt_callback(m::Model, callback::Function)
+function KN_set_newpt_callback(m::Model, callback::Function, userparams=nothing)
     # Store callback function inside model.
-    m.user_callback = callback
+    m.newpt_callback = callback
+    if userparams != nothing
+        m.newpoint_user = userparams
+    end
 
     # Wrap user callback wrapper as C function.
     c_func = @cfunction(newpt_wrapper, Cint,
@@ -681,7 +684,7 @@ function ms_process_wrapper(ptr_model::Ptr{Cvoid},
         nc = KN_get_number_cons(m)
         x = unsafe_wrap(Array, ptr_x, nx)
         lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
-        res = m.ms_process(ptr_model, x, lambda, m)
+        res = m.ms_process(m, x, lambda, m.multistart_user)
         return Cint(res)
     catch ex
         if isa(ex, InterruptException)
@@ -710,9 +713,12 @@ Knitro arguments.  Arguments `x` and `lambda` contain the solution from
 the last solve.
 
 """
-function KN_set_ms_process_callback(m::Model, callback::Function)
+function KN_set_ms_process_callback(m::Model, callback::Function, userparams=nothing)
     # Store callback function inside model.
     m.ms_process = callback
+    if userparams != nothing
+        m.multistart_user = userparams
+    end
 
     # Wrap user callback wrapper as C function.
     c_func = @cfunction(ms_process_wrapper, Cint,
@@ -739,7 +745,7 @@ function mip_node_callback_wrapper(ptr_model::Ptr{Cvoid},
         nc = KN_get_number_cons(m)
         x = unsafe_wrap(Array, ptr_x, nx)
         lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
-        res = m.mip_callback(ptr_model, x, lambda, m)
+        res = m.mip_callback(m, x, lambda, m.mip_user)
         return Cint(res)
     catch ex
         if isa(ex, InterruptException)
@@ -768,9 +774,12 @@ The function should not modify any Knitro arguments.
 Arguments `x` and `lambda` contain the solution from the node solve.
 
 """
-function KN_set_mip_node_callback(m::Model, callback::Function)
+function KN_set_mip_node_callback(m::Model, callback::Function, userparams=nothing)
     # Store callback function inside model.
     m.mip_callback = callback
+    if userparams != nothing
+        m.mip_user = userparams
+    end
 
     # Wrap user callback wrapper as C function.
     c_func = @cfunction(mip_node_callback_wrapper, Cint,
@@ -799,7 +808,7 @@ function ms_initpt_wrapper(ptr_model::Ptr{Cvoid},
 
     x = unsafe_wrap(Array, ptr_x, nx)
     lambda = unsafe_wrap(Array, ptr_lambda, nx + nc)
-    res = m.ms_initpt_callback(ptr_model, nSolveNumber, x, lambda, m)
+    res = m.ms_initpt_callback(m, nSolveNumber, x, lambda, m.multistart_user)
 
     return Cint(res)
 end
@@ -820,9 +829,12 @@ by the user.  The argument `nSolveNumber` is the number of the
 multistart solve.
 
 """
-function KN_set_ms_initpt_callback(m::Model, callback::Function)
+function KN_set_ms_initpt_callback(m::Model, callback::Function, userparams=nothing)
     # Store callback function inside model.
     m.ms_initpt_callback = callback
+    if userparams != nothing
+        m.multistart_user = userparams
+    end
 
     # Wrap user callback wrapper as C function.
     c_func = @cfunction(ms_initpt_wrapper, Cint,
@@ -871,9 +883,12 @@ passed directly from KN_solve. The function should return the number of
 characters that were printed.
 
 """
-function KN_set_puts_callback(m::Model, callback::Function)
+function KN_set_puts_callback(m::Model, callback::Function, userparams=nothing)
     # Store callback function inside model.
     m.puts_callback = callback
+    if userparams != nothing
+        m.puts_user = userparams
+    end
 
     # Wrap user callback wrapper as C function.
     c_func = @cfunction(puts_callback_wrapper, Cint,

--- a/test/knitroapi.jl
+++ b/test/knitroapi.jl
@@ -220,7 +220,7 @@ end
     # Perform a derivative check.
     KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_DERIVCHECK, KNITRO.KN_DERIVCHECK_ALL)
 
-    function newpt_callback(kc_ptr, x, lambda_, kc)
+    function newpt_callback(kc, x, lambda_, user_data)
         a = KNITRO.KN_get_rel_feas_error(kc)
         b = KNITRO.KN_get_rel_opt_error(kc)
         return 0
@@ -626,7 +626,7 @@ end
     nStatus, objSol, x, lambda_ = KNITRO.KN_get_solution(kc)
     @test nStatus == 0
 
-    @test objSol ≈ 21.5848 atol=1e-4
+    @test objSol ≈ 21.5848 atol=1e-3
     @test x ≈ [1., 1.] atol=1e-5
 
     KNITRO.KN_free(kc)
@@ -666,7 +666,7 @@ end
 
     KNITRO.KN_set_compcons(kc, [KNITRO.KN_CCTYPE_VARVAR], Int32[0], Int32[1])
 
-    function newpt_callback(kc_ptr, x, lambda_, kc)
+    function newpt_callback(kc, x, lambda_, user_data)
         if KNITRO.KN_get_number_iters(kc) > 1
             return KNITRO.KN_RC_USER_TERMINATION
         end


### PR DESCRIPTION
Current definition of userparams in special callbacks (multistart, mip, newpoint, user) is mispecified. This PR modifies the wrapper to define properly userparams for these callbacks. 

See #141 

**Important notice:** This PR introduces a breaking change in KNITRO.jl

