### PR TITLE
Fixed spelling of 'example' in the examples

### DIFF
--- a/examples/fcga.jl
+++ b/examples/fcga.jl
@@ -196,7 +196,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple HS40 FCGA" begin
+@testset "Example HS40 FCGA" begin
     @test nStatus == 0
     @test objSol ≈ 0.25
     @test x ≈ [0.793701, 0.707107, 0.529732, 0.840896] atol=1e-5

--- a/examples/lp1.jl
+++ b/examples/lp1.jl
@@ -82,7 +82,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple lp1" begin
+@testset "Example lp1" begin
     @test nStatus == 0
     @test objSol ≈ -17.333333 atol=1e-5
     @test x ≈ [3.667, 1.333, 0, 0] atol=1e-3

--- a/examples/minlp1.jl
+++ b/examples/minlp1.jl
@@ -272,7 +272,7 @@ end
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple minlp1" begin
+@testset "Example minlp1" begin
     @test nStatus == 0
     @test objSol ≈ 6.0097589
     @test x ≈ [1.30097589, 0., 1., 0., 1., 0.] atol=1e-5

--- a/examples/mps_reader.jl
+++ b/examples/mps_reader.jl
@@ -40,7 +40,7 @@ nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple lp1" begin
+@testset "Example lp1" begin
     @test nStatus == 0
     @test objSol ≈ 250 / 3 atol=1e-5
 end

--- a/examples/multipleCB.jl
+++ b/examples/multipleCB.jl
@@ -222,7 +222,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple multipleCB" begin
+@testset "Example multipleCB" begin
     @test nStatus == 0
     @test_broken objSol ≈ 0.25
     @test_broken x ≈ [0.793701, 0.707107, 0.529732, 0.840896] atol=1e-5

--- a/examples/multistart.jl
+++ b/examples/multistart.jl
@@ -225,7 +225,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple HS15 multistart" begin
+@testset "Example HS15 multistart" begin
     @test nStatus == 0
     @test objSol  ≈ 306.5
     @test x ≈ [0.5, 2]

--- a/examples/nlp1.jl
+++ b/examples/nlp1.jl
@@ -193,7 +193,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 # Delete the Knitro solver instance.
 #= KNITRO.KN_free(kc) =#
 
-@testset "Exemple HS15 nlp1" begin
+@testset "Example HS15 nlp1" begin
     @test nStatus == 0
     @test objSol  ≈ 306.5
     @test x ≈ [0.5, 2]

--- a/examples/nlp1noderivs.jl
+++ b/examples/nlp1noderivs.jl
@@ -141,7 +141,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 KNITRO.KN_free(kc)
 
 
-@testset "Exemple HS15 nlp1noderivs" begin
+@testset "Example HS15 nlp1noderivs" begin
     @test nStatus == 0
     @test objSol  ≈ 306.5
     @test x ≈ [0.5, 2]

--- a/examples/nlp2.jl
+++ b/examples/nlp2.jl
@@ -225,7 +225,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple HS40 nlp2" begin
+@testset "Example HS40 nlp2" begin
     @test nStatus == KNITRO.KN_RC_USER_TERMINATION
     @test objSol ≈ 0.25 atol=1e-4
     @test x ≈ [0.793701, 0.707107, 0.529732, 0.840896] atol=1e-4

--- a/examples/qp1.jl
+++ b/examples/qp1.jl
@@ -101,7 +101,7 @@ println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 # Delete the Knitro solver instance.
 KNITRO.KN_free(kc)
 
-@testset "Exemple QP1" begin
+@testset "Example QP1" begin
     @test nStatus == 0
     @test objSol ≈ -0.4861 atol=1e-4
     @test x ≈ [0., 0., -5/6] atol=1e-5


### PR DESCRIPTION
In several of the tests 'example' was spelled 'exemple'. This fixes the spelling.